### PR TITLE
Hamburger menu potential fix

### DIFF
--- a/src/components/Menu/menu.scss
+++ b/src/components/Menu/menu.scss
@@ -383,6 +383,9 @@
     }
     .navbar-toggler{
         position:absolute;
+        outline-color: #ffffff00 !important;
+        border-color: #ffffff00 !important;
+        background-color: #ffffff00 !important;
         left:86.5vw;
         top:5.35vw;
         height:8vw;


### PR DESCRIPTION
Third times a charm (hopefully). Potentially resolves #131 if @deeinstereo and @GeorgeBellTMH think it's ok keeping the hamburger menu static. This PR is virtually identical to my previous attempt #136.

Some explanation: After a sufficient amount of effort, I discovered that changing the background colour _and_ the colour of the hamburger itself this gets really messy with the Bootstrap's `navbar` since the hamburger is an SVG, so I think this is the best solution for now and it's better than doing nothing.