### PR TITLE
Double scrollbar on Firefox bug and search bar fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "HTTPS=true PORT=3006 react-scripts start",
-    "start-pc": "set PORT=3006&& set HTTPS=true&& set BROWSER=firefox&& react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "analyze": "source-map-explorer 'build/static/js/*.js'",
     "start": "HTTPS=true PORT=3006 react-scripts start",
+    "start-pc": "set PORT=3006&& set HTTPS=true&& set BROWSER=firefox&& react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",

--- a/src/components/RenderRouter/HorizontalScrollList.scss
+++ b/src/components/RenderRouter/HorizontalScrollList.scss
@@ -3,7 +3,7 @@
         position: relative;
 
         .HorizontalScrollListItemContainer {
-            overflow-x: scroll;
+            overflow-x: hidden;
 
             &::-webkit-scrollbar {
                 width: 12px;

--- a/src/components/RenderRouter/HorizontalScrollList.scss
+++ b/src/components/RenderRouter/HorizontalScrollList.scss
@@ -5,7 +5,6 @@
         .HorizontalScrollListItemContainer {
             overflow-x: hidden;
 
-
             &::-webkit-scrollbar {
                 width: 12px;
             }

--- a/src/components/RenderRouter/HorizontalScrollList.scss
+++ b/src/components/RenderRouter/HorizontalScrollList.scss
@@ -5,6 +5,7 @@
         .HorizontalScrollListItemContainer {
             overflow-x: hidden;
 
+
             &::-webkit-scrollbar {
                 width: 12px;
             }

--- a/src/components/RenderRouter/SearchItem.scss
+++ b/src/components/RenderRouter/SearchItem.scss
@@ -192,6 +192,7 @@
     }
 
     .SearchLink{
+        display: none;
         $link-width: 24.25vw;
     
         width: $link-width;
@@ -202,6 +203,7 @@
     }
 
     .SearchLinks .HomeChurch{
+        display: none;
         $link-width: 44vw;
     
         width: $link-width;
@@ -245,6 +247,7 @@
     }
 
     .SearchLink{
+        display: none;
         $link-width: 44vw;
     
         width: $link-width;
@@ -255,6 +258,7 @@
     }
 
     .SearchLinks .HomeChurch{
+        display: none;
         $link-width: 100%;
     
         width: $link-width;

--- a/src/components/RenderRouter/SearchItem.scss
+++ b/src/components/RenderRouter/SearchItem.scss
@@ -236,6 +236,7 @@
 
         font-size: 32px;
         line-height: 40px;
+	margin-top: 26px;
     }
 
     .SearchItemDiv{

--- a/src/components/RenderRouter/SearchItem.scss
+++ b/src/components/RenderRouter/SearchItem.scss
@@ -192,7 +192,6 @@
     }
 
     .SearchLink{
-        display: none;
         $link-width: 24.25vw;
     
         width: $link-width;
@@ -203,7 +202,6 @@
     }
 
     .SearchLinks .HomeChurch{
-        display: none;
         $link-width: 44vw;
     
         width: $link-width;
@@ -247,7 +245,6 @@
     }
 
     .SearchLink{
-        display: none;
         $link-width: 44vw;
     
         width: $link-width;
@@ -258,7 +255,6 @@
     }
 
     .SearchLinks .HomeChurch{
-        display: none;
         $link-width: 100%;
     
         width: $link-width;


### PR DESCRIPTION
Resolves #140. Tested on Windows: Firefox (72.0.2), Chrome (79.0.3945.130) and Edge (79.0.309.71).

Also, resolves #143.