### PR TITLE
Header bug (trying again)

### DIFF
--- a/src/components/Menu/menu.scss
+++ b/src/components/Menu/menu.scss
@@ -566,7 +566,7 @@
 
     .navbar-custom {
         position: fixed;
-        background-color:#ffffff;
+        background:#ffffff;
         left: 0;
         right: 0;
         width: 100vw;
@@ -577,7 +577,7 @@
     }
     .navbar-custom.white{
         position: fixed;
-        background-color:#000000 !important;
+        background:#000000 !important;
         left: 0;
         right: 0;
         width: 100vw;

--- a/src/components/VideoOverlay/VideoOverlay.scss
+++ b/src/components/VideoOverlay/VideoOverlay.scss
@@ -130,7 +130,7 @@
     .modal-video {
         width: 100%;
         max-width: none !important;
-        color: #000000 !important;
+        background-color: #000000 !important;
         margin: 0 !important;
     }
 

--- a/src/components/VideoOverlay/VideoOverlay.scss
+++ b/src/components/VideoOverlay/VideoOverlay.scss
@@ -125,12 +125,13 @@
     .modal-content {
         border: none;
         border-radius: 0;
+        background-color: #ffffff00 !important;
     }
 
     .modal-video {
         width: 100%;
         max-width: none !important;
-        background-color: #000000 !important;
+        background-color: #000000;
         margin: 0 !important;
     }
 


### PR DESCRIPTION
Doesn't look like #206 did the trick.

In this PR:
- make `modal-content` transparent (`#ffffff00`)
- use `background` on the navbar since it overwrites `background-color`

Once again unsure if this will work on the server. Shouldn't be any breaking changes.