### PR TITLE
Remove Oakville/Regional toggle

### DIFF
--- a/public/static/content/teaching.json
+++ b/public/static/content/teaching.json
@@ -20,7 +20,7 @@
                 "style": "hero",
                 "class": "teaching-sunday",
                 "header1":"Teaching - Sunday Teaching",
-                "options":["Oakville","Regional"],
+                "options":[],
                 "group":"teaching",
                 "subclass":"adult-sunday",
                 "sortOrder":"DESC"


### PR DESCRIPTION
Fixes #217.

Removes Oakville/Regional toggle on https://www.themeetinghouse.com/teaching

