### PR TITLE
Remove non-functional scroll bars

### DIFF
--- a/src/components/RenderRouter/ListItem.scss
+++ b/src/components/RenderRouter/ListItem.scss
@@ -22,7 +22,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -43,7 +42,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -142,7 +140,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -391,7 +388,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -412,7 +408,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -510,7 +505,6 @@
         position: relative;
         left: 0vw;
         width: 80vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -794,7 +788,6 @@
         position: relative;
         left: 0vw;
         width: 95vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -816,7 +809,6 @@
         position: relative;
         left: 0vw;
         width: 95vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 
@@ -935,7 +927,6 @@
         position: relative;
         left: 0vw;
         width: 95vw;
-        overflow-x: scroll;
         white-space: nowrap;
     }
 


### PR DESCRIPTION
Resolves #220. Retains previous level of functionality. Tested across all window sizes on Chrome, Firefox, Edge, Safari. 