### PR TITLE
Remove spin animation

### DIFF
--- a/src/custom.scss
+++ b/src/custom.scss
@@ -218,8 +218,7 @@ html{
 
     .imageList .hoverText:hover{
         .arrow {
-            transition: 2s;
-            transform: rotate(720deg);
+            transform: none;
         }
     }
 }


### PR DESCRIPTION
The little spin effect I added was fun while it lasted, but on an actual mobile device, you a split second of the animation after you click, then the page redirects.

![arrow](https://user-images.githubusercontent.com/48423418/82008479-d429cc00-963a-11ea-8287-1d4ddbd1fb51.gif)

Looks kinda janky tbh. This PR removes all animation on mobile.