### PR TITLE
Refactor DataLoader to make typing easier

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,13 @@
   "editor.formatOnSave": true,
   "[graphql]": {
     "editor.formatOnSave": false
+  },
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true,
+    "node_modules": true
   }
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  roots: ['<rootDir>/src'],
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  testRegex: '.spec.tsx?$',
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2068,6 +2068,32 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
+    "@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.1.tgz",
+      "integrity": "sha512-Gf2Yx/iRs1JREDtVZ56OrjjgFHCaldpTnuy9BHla10qyVT3YkIIGEtoDWhyop0ksu1GvNjHIoYRBqm3zoR1jyQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
+          "integrity": "sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-decorators": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
@@ -2092,6 +2118,23 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-syntax-import-meta": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.1.tgz",
+      "integrity": "sha512-ypC4jwfIVF72og0dgvEcFRdOM2V9Qm1tu7RGmdZOlhsccyK0wisXmMObGuWEOd5jQ+K9wcIgSNftCpk2vkjUfQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
+          "integrity": "sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-syntax-json-strings": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
@@ -2106,6 +2149,23 @@
       "integrity": "sha512-WxdW9xyLgBdefoo0Ynn3MRSkhe5tFVxxKNVdnZSh318WrG2e2jH+E9wd/++JsqcLJZPfz87njQJ8j2Upjm0M0A==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.1.tgz",
+      "integrity": "sha512-XyHIFa9kdrgJS91CUH+ccPVTnJShr8nLGc5bG2IhGXv5p1Rd+8BleGE5yzIg2Nc1QZAdHDa0Qp4m6066OL96Iw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.10.1"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.10.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.3.tgz",
+          "integrity": "sha512-j/+j8NAWUTxOtx4LKHybpSClxHoq6I91DQ/mKgAXn5oNUPIUiGppjPIX3TDtJWPrdfP9Kfl7e4fgVMiQR9VE/g==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-nullish-coalescing-operator": {
@@ -2736,6 +2796,22 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "@cnakazawa/watch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@cnakazawa/watch/-/watch-1.0.4.tgz",
+      "integrity": "sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==",
+      "dev": true,
+      "requires": {
+        "exec-sh": "^0.3.2",
+        "minimist": "^1.2.0"
+      }
+    },
     "@csstools/convert-colors": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@csstools/convert-colors/-/convert-colors-1.4.0.tgz",
@@ -2870,6 +2946,67 @@
       "requires": {
         "@hapi/hoek": "^8.3.0"
       }
+    },
+    "@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        }
+      }
+    },
+    "@istanbuljs/schema": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.2.tgz",
+      "integrity": "sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==",
+      "dev": true
     },
     "@jest/console": {
       "version": "24.9.0",
@@ -4204,6 +4341,114 @@
           "requires": {
             "is-number": "^3.0.0",
             "repeat-string": "^1.6.1"
+          }
+        }
+      }
+    },
+    "@jest/globals": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.1.0.tgz",
+      "integrity": "sha512-MKiHPNaT+ZoG85oMaYUmGHEqu98y3WO2yeIDJrs2sJqHhYOy3Z6F7F/luzFomRQ8SQ1wEkmahFAz2291Iv8EAw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "expect": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -6891,6 +7136,15 @@
         "type-detect": "4.0.8"
       }
     },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "@sinonjs/formatio": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
@@ -7125,6 +7379,15 @@
         "@types/node": "*"
       }
     },
+    "@types/graceful-fs": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.3.tgz",
+      "integrity": "sha512-AiHRaEB50LQg0pZmm659vNBb9f4SJ0qrAnteuzhSeAUcJKxoYgEnprg/83kppCnc2zvtCKbdZry1a5pVY3lOTQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/history": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.5.tgz",
@@ -7181,6 +7444,131 @@
         "@types/istanbul-lib-report": "*"
       }
     },
+    "@types/jest": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-26.0.0.tgz",
+      "integrity": "sha512-/yeMsH9HQ1RLORlXAwoLXe8S98xxvhNtUz3yrgrwbaxYjT+6SFPZZRksmRKRA6L5vsUtSHeN71viDOTTyYAD+g==",
+      "dev": true,
+      "requires": {
+        "jest-diff": "^25.2.1",
+        "pretty-format": "^25.2.1"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-25.5.0.tgz",
+          "integrity": "sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^3.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
+          "integrity": "sha512-Hq8o7+6GaZeoFjtpgvRBUknSXNeJiCx7V9Fr94ZMljNiCr9n9L8H8aJqgWOQiDDGdyn29fRNcDdRVJ5fdyihfg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-diff": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-25.5.0.tgz",
+          "integrity": "sha512-z1kygetuPiREYdNIumRpAHY6RXiGmp70YHptjdaxTWGmA085W3iCnXNx0DhflK3vwrKmrRWyY1wUpkPMVxMK7A==",
+          "dev": true,
+          "requires": {
+            "chalk": "^3.0.0",
+            "diff-sequences": "^25.2.6",
+            "jest-get-type": "^25.2.6",
+            "pretty-format": "^25.5.0"
+          }
+        },
+        "jest-get-type": {
+          "version": "25.2.6",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-25.2.6.tgz",
+          "integrity": "sha512-DxjtyzOHjObRM+sM1knti6or+eOgcGU4xVSb2HNP1TqO4ahsT+rqZg+nyqHWJSvWgKC5cG3QjGFBqxLghiF/Ig==",
+          "dev": true
+        },
+        "pretty-format": {
+          "version": "25.5.0",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.5.0.tgz",
+          "integrity": "sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^25.5.0",
+            "ansi-regex": "^5.0.0",
+            "ansi-styles": "^4.0.0",
+            "react-is": "^16.12.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.4.tgz",
@@ -7213,6 +7601,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.7.7.tgz",
       "integrity": "sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg=="
     },
+    "@types/normalize-package-data": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
+      "dev": true
+    },
     "@types/object-assign": {
       "version": "4.0.30",
       "resolved": "https://registry.npmjs.org/@types/object-assign/-/object-assign-4.0.30.tgz",
@@ -7222,6 +7616,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
+    "@types/prettier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.0.1.tgz",
+      "integrity": "sha512-boy4xPNEtiw6N3abRhBi/e7hNvy3Tt8E9ZRAQrwAGzoCGZS/1wjo9KY7JHhnfnEsG5wSjDbymCozUM9a3ea7OQ==",
+      "dev": true
     },
     "@types/prop-types": {
       "version": "15.7.3",
@@ -7672,6 +8072,12 @@
       "resolved": "https://registry.npmjs.org/JSV/-/JSV-4.0.2.tgz",
       "integrity": "sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c="
     },
+    "abab": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.3.tgz",
+      "integrity": "sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -7691,6 +8097,24 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
       "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
+    },
+    "acorn-globals": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-6.0.0.tgz",
+      "integrity": "sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.1.1",
+        "acorn-walk": "^7.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.2.0.tgz",
+          "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
+          "dev": true
+        }
+      }
     },
     "acorn-jsx": {
       "version": "5.2.0",
@@ -8156,8 +8580,7 @@
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-      "optional": true
+      "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -8207,8 +8630,7 @@
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-      "optional": true
+      "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -8471,6 +8893,124 @@
         "babylon": "^6.18.0"
       }
     },
+    "babel-jest": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.1.0.tgz",
+      "integrity": "sha512-Nkqgtfe7j6PxLO6TnCQQlkMm8wdTdnIF8xrdpooHCuD5hXRzVEPbPneTJKknH5Dsv3L8ip9unHDAp48YQ54Dkg==",
+      "dev": true,
+      "requires": {
+        "@jest/transform": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "@types/babel__core": "^7.1.7",
+        "babel-plugin-istanbul": "^6.0.0",
+        "babel-preset-jest": "^26.1.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/transform": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
+          "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^26.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "babel-loader": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.1.0.tgz",
@@ -8533,6 +9073,31 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
+      }
+    },
+    "babel-plugin-istanbul": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.0.0.tgz",
+      "integrity": "sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^4.0.0",
+        "test-exclude": "^6.0.0"
+      }
+    },
+    "babel-plugin-jest-hoist": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.1.0.tgz",
+      "integrity": "sha512-qhqLVkkSlqmC83bdMhM8WW4Z9tB+JkjqAqlbbohS9sJLT5Ha2vfzuKqg5yenXrAjOPG2YC0WiXdH3a9PvB+YYw==",
+      "dev": true,
+      "requires": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.0.0",
+        "@types/babel__traverse": "^7.0.6"
       }
     },
     "babel-plugin-macros": {
@@ -8615,6 +9180,35 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.24.tgz",
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
+    },
+    "babel-preset-current-node-syntax": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
+      "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.8.3",
+        "@babel/plugin-syntax-import-meta": "^7.8.3",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.8.3",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
+      }
+    },
+    "babel-preset-jest": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.1.0.tgz",
+      "integrity": "sha512-na9qCqFksknlEj5iSdw1ehMVR06LCCTkZLGKeEtxDDdhg8xpUF09m29Kvh1pRbZ07h7AQ5ttLYUwpXL4tO6w7w==",
+      "dev": true,
+      "requires": {
+        "babel-plugin-jest-hoist": "^26.1.0",
+        "babel-preset-current-node-syntax": "^0.1.2"
+      }
     },
     "babel-preset-react-app": {
       "version": "9.1.2",
@@ -9093,6 +9687,15 @@
         "pkg-up": "^2.0.0"
       }
     },
+    "bs-logger": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bs-logger/-/bs-logger-0.2.6.tgz",
+      "integrity": "sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==",
+      "dev": true,
+      "requires": {
+        "fast-json-stable-stringify": "2.x"
+      }
+    },
     "bser": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.1.1.tgz",
@@ -9305,6 +9908,15 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001048.tgz",
       "integrity": "sha512-g1iSHKVxornw0K8LG9LLdf+Fxnv7T1Z+mMsf0/YYLclQX4Cd522Ap0Lrw6NFqHgezit78dtyWxzlV2Xfc7vgRg=="
     },
+    "capture-exit": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/capture-exit/-/capture-exit-2.0.0.tgz",
+      "integrity": "sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==",
+      "dev": true,
+      "requires": {
+        "rsvp": "^4.8.4"
+      }
+    },
     "case-sensitive-paths-webpack-plugin": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.3.0.tgz",
@@ -9334,6 +9946,12 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/change-emitter/-/change-emitter-0.1.6.tgz",
       "integrity": "sha1-6LL+PX8at9aaMhma/5HqaTFAlRU="
+    },
+    "char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "dev": true
     },
     "chardet": {
       "version": "0.7.0",
@@ -9415,6 +10033,12 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "ci-info": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+      "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -9540,6 +10164,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+    },
+    "collect-v8-coverage": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.1.tgz",
+      "integrity": "sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -10154,46 +10784,16 @@
       }
     },
     "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "dev": true,
       "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      },
-      "dependencies": {
-        "path-key": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-          "dev": true
-        },
-        "shebang-command": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-          "dev": true,
-          "requires": {
-            "shebang-regex": "^3.0.0"
-          }
-        },
-        "shebang-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-          "dev": true
-        },
-        "which": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-          "dev": true,
-          "requires": {
-            "isexe": "^2.0.0"
-          }
-        }
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "crypto-browserify": {
@@ -10461,6 +11061,15 @@
       "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
+    "cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "requires": {
+        "cssom": "~0.3.6"
+      }
+    },
     "csstype": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.9.tgz",
@@ -10564,6 +11173,12 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
+    "decimal.js": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
+      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw==",
+      "dev": true
+    },
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
@@ -10588,9 +11203,10 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
-      "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -11319,6 +11935,17 @@
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
         "eslint-scope": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
@@ -11384,6 +12011,12 @@
             "word-wrap": "^1.2.3"
           }
         },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
         "prelude-ls": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11394,6 +12027,21 @@
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
           "dev": true
         },
         "strip-ansi": {
@@ -11421,6 +12069,15 @@
           "dev": true,
           "requires": {
             "prelude-ls": "^1.2.1"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -11871,6 +12528,27 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "exec-sh": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.3.4.tgz",
+      "integrity": "sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==",
+      "dev": true
+    },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
     "exenv": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
@@ -11885,7 +12563,6 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-      "optional": true,
       "requires": {
         "debug": "^2.3.3",
         "define-property": "^0.2.5",
@@ -11900,7 +12577,6 @@
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -11909,7 +12585,6 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "optional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -11918,7 +12593,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -11926,8 +12600,94 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
+    "expect": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-26.1.0.tgz",
+      "integrity": "sha512-QbH4LZXDsno9AACrN9eM0zfnby9G+OsdNgZUohjg/P0mLy1O+/bzTAJGT6VSIjVCe8yKM6SzEl/ckEOFBT7Vnw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "ansi-styles": "^4.0.0",
+        "jest-get-type": "^26.0.0",
+        "jest-matcher-utils": "^26.1.0",
+        "jest-message-util": "^26.1.0",
+        "jest-regex-util": "^26.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -12041,7 +12801,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-      "optional": true,
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -12057,7 +12816,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-          "optional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -12066,7 +12824,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "optional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -12075,7 +12832,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -12084,7 +12840,6 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-          "optional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -12093,7 +12848,6 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-          "optional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -12103,8 +12857,7 @@
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "optional": true
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         }
       }
     },
@@ -12134,9 +12887,9 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fast-xml-parser": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.4.tgz",
-      "integrity": "sha512-qudnQuyYBgnvzf5Lj/yxMcf4L9NcVWihXJg7CiU1L+oUCq8MUnFEfH2/nXR/W5uq+yvUN1h7z6s7vs2v1WkL1A=="
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.17.1.tgz",
+      "integrity": "sha512-jZ0EVn1iBuZtx/sbQnfvhSaaUltz+0+yfR+6QRyzrlt5yMiU+8ZfGj9i3/hoXJxm+aFri7dycBWbncox7frCAQ=="
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -12355,6 +13108,16 @@
         "flatted": "^2.0.0",
         "rimraf": "2.6.3",
         "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
       }
     },
     "flatted": {
@@ -13394,10 +14157,25 @@
       "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
       "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
     },
+    "get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "dev": true
+    },
     "get-stdin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -14294,6 +15072,12 @@
         "debug": "4"
       }
     },
+    "human-signals": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+      "dev": true
+    },
     "humanize-url": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/humanize-url/-/humanize-url-1.0.1.tgz",
@@ -14714,6 +15498,15 @@
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
       "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
     },
+    "is-ci": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-2.0.0.tgz",
+      "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
+      "dev": true,
+      "requires": {
+        "ci-info": "^2.0.0"
+      }
+    },
     "is-color-stop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-color-stop/-/is-color-stop-1.1.0.tgz",
@@ -14856,6 +15649,12 @@
         }
       }
     },
+    "is-potential-custom-element-name": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.0.tgz",
+      "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -14943,8 +15742,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "optional": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -14980,6 +15778,96 @@
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
+    "istanbul-lib-coverage": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.0.0.tgz",
+      "integrity": "sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
+      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.7.5",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.0.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
+      }
+    },
+    "istanbul-lib-report": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "dev": true,
+      "requires": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^3.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.0.0"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.0.tgz",
+      "integrity": "sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      }
+    },
+    "istanbul-reports": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
+      "integrity": "sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==",
+      "dev": true,
+      "requires": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      }
+    },
     "iterall": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
@@ -15000,6 +15888,896 @@
           "version": "0.9.2",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
           "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
+        }
+      }
+    },
+    "jest": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.1.0.tgz",
+      "integrity": "sha512-LIti8jppw5BcQvmNJe4w2g1N/3V68HUfAv9zDVm7v+VAtQulGhH0LnmmiVkbNE4M4I43Bj2fXPiBGKt26k9tHw==",
+      "dev": true,
+      "requires": {
+        "@jest/core": "^26.1.0",
+        "import-local": "^3.0.2",
+        "jest-cli": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/core": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.1.0.tgz",
+          "integrity": "sha512-zyizYmDJOOVke4OO/De//aiv8b07OwZzL2cfsvWF3q9YssfpcKfcnZAwDY8f+A76xXSMMYe8i/f/LPocLlByfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/reporters": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "jest-changed-files": "^26.1.0",
+            "jest-config": "^26.1.0",
+            "jest-haste-map": "^26.1.0",
+            "jest-message-util": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-resolve": "^26.1.0",
+            "jest-resolve-dependencies": "^26.1.0",
+            "jest-runner": "^26.1.0",
+            "jest-runtime": "^26.1.0",
+            "jest-snapshot": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-validate": "^26.1.0",
+            "jest-watcher": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "p-each-series": "^2.1.0",
+            "rimraf": "^3.0.0",
+            "slash": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "@jest/reporters": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.1.0.tgz",
+          "integrity": "sha512-SVAysur9FOIojJbF4wLP0TybmqwDkdnFxHSPzHMMIYyBtldCW9gG+Q5xWjpMFyErDiwlRuPyMSJSU64A67Pazg==",
+          "dev": true,
+          "requires": {
+            "@bcoe/v8-coverage": "^0.2.3",
+            "@jest/console": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/transform": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "collect-v8-coverage": "^1.0.0",
+            "exit": "^0.1.2",
+            "glob": "^7.1.2",
+            "graceful-fs": "^4.2.4",
+            "istanbul-lib-coverage": "^3.0.0",
+            "istanbul-lib-instrument": "^4.0.3",
+            "istanbul-lib-report": "^3.0.0",
+            "istanbul-lib-source-maps": "^4.0.0",
+            "istanbul-reports": "^3.0.2",
+            "jest-haste-map": "^26.1.0",
+            "jest-resolve": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-worker": "^26.1.0",
+            "node-notifier": "^7.0.0",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.0",
+            "string-length": "^4.0.1",
+            "terminal-link": "^2.0.0",
+            "v8-to-istanbul": "^4.1.3"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
+          "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^26.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "import-local": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.0.2.tgz",
+          "integrity": "sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==",
+          "dev": true,
+          "requires": {
+            "pkg-dir": "^4.2.0",
+            "resolve-cwd": "^3.0.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-wsl": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+          "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "is-docker": "^2.0.0"
+          }
+        },
+        "jest-cli": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.1.0.tgz",
+          "integrity": "sha512-Imumvjgi3rU7stq6SJ1JUEMaV5aAgJYXIs0jPqdUnF47N/Tk83EXfmtvNKQ+SnFVI6t6mDOvfM3aA9Sg6kQPSw==",
+          "dev": true,
+          "requires": {
+            "@jest/core": "^26.1.0",
+            "@jest/test-result": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "exit": "^0.1.2",
+            "graceful-fs": "^4.2.4",
+            "import-local": "^3.0.2",
+            "is-ci": "^2.0.0",
+            "jest-config": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "jest-validate": "^26.1.0",
+            "prompts": "^2.0.1",
+            "yargs": "^15.3.1"
+          }
+        },
+        "jest-watcher": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.1.0.tgz",
+          "integrity": "sha512-ffEOhJl2EvAIki613oPsSG11usqnGUzIiK7MMX6hE4422aXOcVEG3ySCTDFLn1+LZNXGPE8tuJxhp8OBJ1pgzQ==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "ansi-escapes": "^4.2.1",
+            "chalk": "^4.0.0",
+            "jest-util": "^26.1.0",
+            "string-length": "^4.0.1"
+          }
+        },
+        "jest-worker": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
+          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "node-notifier": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-7.0.1.tgz",
+          "integrity": "sha512-VkzhierE7DBmQEElhTGJIoiZa1oqRijOtgOlsXg32KrJRXsPy0NXFBqWGW/wTswnJlDCs5viRYaqWguqzsKcmg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "growly": "^1.3.0",
+            "is-wsl": "^2.1.1",
+            "semver": "^7.2.1",
+            "shellwords": "^0.1.1",
+            "uuid": "^7.0.3",
+            "which": "^2.0.2"
+          }
+        },
+        "p-each-series": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.1.0.tgz",
+          "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
+          "dev": true
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "pkg-dir": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.0.0"
+          }
+        },
+        "resolve-cwd": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+          "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+          "dev": true,
+          "requires": {
+            "resolve-from": "^5.0.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true,
+          "optional": true
+        },
+        "string-length": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.1.tgz",
+          "integrity": "sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==",
+          "dev": true,
+          "requires": {
+            "char-regex": "^1.0.2",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        },
+        "uuid": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "dev": true,
+          "optional": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
+    "jest-changed-files": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.1.0.tgz",
+      "integrity": "sha512-HS5MIJp3B8t0NRKGMCZkcDUZo36mVRvrDETl81aqljT1S9tqiHRSpyoOvWg9ZilzZG9TDisDNaN1IXm54fLRZw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "execa": "^4.0.0",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+          "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "execa": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.2.tgz",
+          "integrity": "sha512-QI2zLa6CjGWdiQsmSkZoGtDx2N+cQIGb3yNolGTdjSQzydzLgYYf8LRuagp7S7fPimjcrzUDSUFd/MgzELMi4Q==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+          "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "jest-config": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.1.0.tgz",
+      "integrity": "sha512-ONTGeoMbAwGCdq4WuKkMcdMoyfs5CLzHEkzFOlVvcDXufZSaIWh/OXMLa2fwKXiOaFcqEw8qFr4VOKJQfn4CVw==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.1.0",
+        "@jest/test-sequencer": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "babel-jest": "^26.1.0",
+        "chalk": "^4.0.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.1",
+        "graceful-fs": "^4.2.4",
+        "jest-environment-jsdom": "^26.1.0",
+        "jest-environment-node": "^26.1.0",
+        "jest-get-type": "^26.0.0",
+        "jest-jasmine2": "^26.1.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "jest-validate": "^26.1.0",
+        "micromatch": "^4.0.2",
+        "pretty-format": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/test-sequencer": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.1.0.tgz",
+          "integrity": "sha512-Z/hcK+rTq56E6sBwMoQhSRDVjqrGtj1y14e2bIgcowARaIE1SgOanwx6gvY4Q9gTKMoZQXbXvptji+q5GYxa6Q==",
+          "dev": true,
+          "requires": {
+            "@jest/test-result": "^26.1.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-runner": "^26.1.0",
+            "jest-runtime": "^26.1.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-diff": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.1.0.tgz",
+      "integrity": "sha512-GZpIcom339y0OXznsEKjtkfKxNdg7bVbEofK8Q6MnevTIiR1jNhDWKhRX6X0SDXJlwn3dy59nZ1z55fLkAqPWg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^26.0.0",
+        "jest-get-type": "^26.0.0",
+        "pretty-format": "^26.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "diff-sequences": {
+          "version": "26.0.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.0.0.tgz",
+          "integrity": "sha512-JC/eHYEC3aSS0vZGjuoc4vHA0yAQTzhQQldXMeMF+JlxLGJlCO38Gma82NV9gk1jGFz8mDzUMeaKXvjRRdJ2dg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-docblock": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-26.0.0.tgz",
+      "integrity": "sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==",
+      "dev": true,
+      "requires": {
+        "detect-newline": "^3.0.0"
+      },
+      "dependencies": {
+        "detect-newline": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+          "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+          "dev": true
         }
       }
     },
@@ -15072,6 +16850,117 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
           "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A=="
+        }
+      }
+    },
+    "jest-environment-jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.1.0.tgz",
+      "integrity": "sha512-dWfiJ+spunVAwzXbdVqPH1LbuJW/kDL+FyqgA5YzquisHqTi0g9hquKif9xKm7c1bKBj6wbmJuDkeMCnxZEpUw==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.1.0",
+        "@jest/fake-timers": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "jest-mock": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "jsdom": "^16.2.2"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -15241,6 +17130,462 @@
         }
       }
     },
+    "jest-environment-node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.1.0.tgz",
+      "integrity": "sha512-DNm5x1aQH0iRAe9UYAkZenuzuJ69VKzDCAYISFHQ5i9e+2Tbeu2ONGY7YStubCLH8a1wdKBgqScYw85+ySxqxg==",
+      "dev": true,
+      "requires": {
+        "@jest/environment": "^26.1.0",
+        "@jest/fake-timers": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "jest-mock": "^26.1.0",
+        "jest-util": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-get-type": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-26.0.0.tgz",
+      "integrity": "sha512-zRc1OAPnnws1EVfykXOj19zo2EMw5Hi6HLbFCSjpuJiXtOWAYIjNsHVSbpQ8bDX7L5BGYGI8m+HmKdjHYFF0kg==",
+      "dev": true
+    },
+    "jest-haste-map": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.1.0.tgz",
+      "integrity": "sha512-WeBS54xCIz9twzkEdm6+vJBXgRBQfdbbXD0dk8lJh7gLihopABlJmIQFdWSDDtuDe4PRiObsjZSUjbJ1uhWEpA==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "@types/graceful-fs": "^4.1.2",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-serializer": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "jest-worker": "^26.1.0",
+        "micromatch": "^4.0.2",
+        "sane": "^4.0.3",
+        "walker": "^1.0.7",
+        "which": "^2.0.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "anymatch": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
+          "dev": true,
+          "requires": {
+            "normalize-path": "^3.0.0",
+            "picomatch": "^2.0.4"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-serializer": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.1.0.tgz",
+          "integrity": "sha512-eqZOQG/0+MHmr25b2Z86g7+Kzd5dG9dhCiUoyUNJPgiqi38DqbDEOlHcNijyfZoj74soGBohKBZuJFS18YTJ5w==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.4"
+          }
+        },
+        "jest-worker": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
+          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "normalize-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "jest-jasmine2": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.1.0.tgz",
+      "integrity": "sha512-1IPtoDKOAG+MeBrKvvuxxGPJb35MTTRSDglNdWWCndCB3TIVzbLThRBkwH9P081vXLgiJHZY8Bz3yzFS803xqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/traverse": "^7.1.0",
+        "@jest/environment": "^26.1.0",
+        "@jest/source-map": "^26.1.0",
+        "@jest/test-result": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "expect": "^26.1.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^26.1.0",
+        "jest-matcher-utils": "^26.1.0",
+        "jest-message-util": "^26.1.0",
+        "jest-runtime": "^26.1.0",
+        "jest-snapshot": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "pretty-format": "^26.1.0",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
+          "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.4",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-each": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.1.0.tgz",
+          "integrity": "sha512-lYiSo4Igr81q6QRsVQq9LIkJW0hZcKxkIkHzNeTMPENYYDw/W/Raq28iJ0sLlNFYz2qxxeLnc5K2gQoFYlu2bA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-get-type": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        }
+      }
+    },
     "jest-leak-detector": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz",
@@ -15268,15 +17613,1347 @@
         }
       }
     },
+    "jest-matcher-utils": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.1.0.tgz",
+      "integrity": "sha512-PW9JtItbYvES/xLn5mYxjMd+Rk+/kIt88EfH3N7w9KeOrHWaHrdYPnVHndGbsFGRJ2d5gKtwggCvkqbFDoouQA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^26.1.0",
+        "jest-get-type": "^26.0.0",
+        "pretty-format": "^26.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-message-util": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.1.0.tgz",
+      "integrity": "sha512-dY0+UlldiAJwNDJ08SF0HdF32g9PkbF2NRK/+2iMPU40O6q+iSn1lgog/u0UH8ksWoPv0+gNq8cjhYO2MFtT0g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@jest/types": "^26.1.0",
+        "@types/stack-utils": "^1.0.1",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "micromatch": "^4.0.2",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+          "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "stack-utils": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.2.tgz",
+          "integrity": "sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==",
+          "dev": true,
+          "requires": {
+            "escape-string-regexp": "^2.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-mock": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.1.0.tgz",
+      "integrity": "sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",
       "integrity": "sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ=="
     },
+    "jest-regex-util": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
+      "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
+      "dev": true
+    },
+    "jest-resolve": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.1.0.tgz",
+      "integrity": "sha512-KsY1JV9FeVgEmwIISbZZN83RNGJ1CC+XUCikf/ZWJBX/tO4a4NvA21YixokhdR9UnmPKKAC4LafVixJBrwlmfg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "jest-pnp-resolver": "^1.2.1",
+        "jest-util": "^26.1.0",
+        "read-pkg-up": "^7.0.1",
+        "resolve": "^1.17.0",
+        "slash": "^3.0.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+          "dev": true,
+          "requires": {
+            "@types/normalize-package-data": "^2.4.0",
+            "normalize-package-data": "^2.5.0",
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
+          },
+          "dependencies": {
+            "type-fest": {
+              "version": "0.6.0",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+              "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+              "dev": true
+            }
+          }
+        },
+        "read-pkg-up": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+          "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+          "dev": true,
+          "requires": {
+            "find-up": "^4.1.0",
+            "read-pkg": "^5.2.0",
+            "type-fest": "^0.8.1"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-resolve-dependencies": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.1.0.tgz",
+      "integrity": "sha512-fQVEPHHQ1JjHRDxzlLU/buuQ9om+hqW6Vo928aa4b4yvq4ZHBtRSDsLdKQLuCqn5CkTVpYZ7ARh2fbA8WkRE6g==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-snapshot": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-runner": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.1.0.tgz",
+      "integrity": "sha512-elvP7y0fVDREnfqit0zAxiXkDRSw6dgCkzPCf1XvIMnSDZ8yogmSKJf192dpOgnUVykmQXwYYJnCx641uLTgcw==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.1.0",
+        "@jest/environment": "^26.1.0",
+        "@jest/test-result": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.1.0",
+        "jest-docblock": "^26.0.0",
+        "jest-haste-map": "^26.1.0",
+        "jest-jasmine2": "^26.1.0",
+        "jest-leak-detector": "^26.1.0",
+        "jest-message-util": "^26.1.0",
+        "jest-resolve": "^26.1.0",
+        "jest-runtime": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "jest-worker": "^26.1.0",
+        "source-map-support": "^0.5.6",
+        "throat": "^5.0.0"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "jest-leak-detector": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.1.0.tgz",
+          "integrity": "sha512-dsMnKF+4BVOZwvQDlgn3MG+Ns4JuLv8jNvXH56bgqrrboyCbI1rQg6EI5rs+8IYagVcfVP2yZFKfWNZy0rK0Hw==",
+          "dev": true,
+          "requires": {
+            "jest-get-type": "^26.0.0",
+            "pretty-format": "^26.1.0"
+          }
+        },
+        "jest-worker": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.1.0.tgz",
+          "integrity": "sha512-Z9P5pZ6UC+kakMbNJn+tA2RdVdNX5WH1x+5UCBZ9MxIK24pjYtFt96fK+UwBTrjLYm232g1xz0L3eTh51OW+yQ==",
+          "dev": true,
+          "requires": {
+            "merge-stream": "^2.0.0",
+            "supports-color": "^7.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "throat": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
+          "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
+          "dev": true
+        }
+      }
+    },
+    "jest-runtime": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.1.0.tgz",
+      "integrity": "sha512-1qiYN+EZLmG1QV2wdEBRf+Ci8i3VSfIYLF02U18PiUDrMbhfpN/EAMMkJtT02jgJUoaEOpHAIXG6zS3QRMzRmA==",
+      "dev": true,
+      "requires": {
+        "@jest/console": "^26.1.0",
+        "@jest/environment": "^26.1.0",
+        "@jest/fake-timers": "^26.1.0",
+        "@jest/globals": "^26.1.0",
+        "@jest/source-map": "^26.1.0",
+        "@jest/test-result": "^26.1.0",
+        "@jest/transform": "^26.1.0",
+        "@jest/types": "^26.1.0",
+        "@types/yargs": "^15.0.0",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.4",
+        "jest-config": "^26.1.0",
+        "jest-haste-map": "^26.1.0",
+        "jest-message-util": "^26.1.0",
+        "jest-mock": "^26.1.0",
+        "jest-regex-util": "^26.0.0",
+        "jest-resolve": "^26.1.0",
+        "jest-snapshot": "^26.1.0",
+        "jest-util": "^26.1.0",
+        "jest-validate": "^26.1.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0",
+        "yargs": "^15.3.1"
+      },
+      "dependencies": {
+        "@jest/console": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.1.0.tgz",
+          "integrity": "sha512-+0lpTHMd/8pJp+Nd4lyip+/Iyf2dZJvcCqrlkeZQoQid+JlThA4M9vxHtheyrQ99jJTMQam+es4BcvZ5W5cC3A==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "chalk": "^4.0.0",
+            "jest-message-util": "^26.1.0",
+            "jest-util": "^26.1.0",
+            "slash": "^3.0.0"
+          }
+        },
+        "@jest/environment": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.1.0.tgz",
+          "integrity": "sha512-86+DNcGongbX7ai/KE/S3/NcUVZfrwvFzOOWX/W+OOTvTds7j07LtC+MgGydH5c8Ri3uIrvdmVgd1xFD5zt/xA==",
+          "dev": true,
+          "requires": {
+            "@jest/fake-timers": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "jest-mock": "^26.1.0"
+          }
+        },
+        "@jest/fake-timers": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.1.0.tgz",
+          "integrity": "sha512-Y5F3kBVWxhau3TJ825iuWy++BAuQzK/xEa+wD9vDH3RytW9f2DbMVodfUQC54rZDX3POqdxCgcKdgcOL0rYUpA==",
+          "dev": true,
+          "requires": {
+            "@jest/types": "^26.1.0",
+            "@sinonjs/fake-timers": "^6.0.1",
+            "jest-message-util": "^26.1.0",
+            "jest-mock": "^26.1.0",
+            "jest-util": "^26.1.0"
+          }
+        },
+        "@jest/source-map": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.1.0.tgz",
+          "integrity": "sha512-XYRPYx4eEVX15cMT9mstnO7hkHP3krNtKfxUYd8L7gbtia8JvZZ6bMzSwa6IQJENbudTwKMw5R1BePRD+bkEmA==",
+          "dev": true,
+          "requires": {
+            "callsites": "^3.0.0",
+            "graceful-fs": "^4.2.4",
+            "source-map": "^0.6.0"
+          }
+        },
+        "@jest/test-result": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.1.0.tgz",
+          "integrity": "sha512-Xz44mhXph93EYMA8aYDz+75mFbarTV/d/x0yMdI3tfSRs/vh4CqSxgzVmCps1fPkHDCtn0tU8IH9iCKgGeGpfw==",
+          "dev": true,
+          "requires": {
+            "@jest/console": "^26.1.0",
+            "@jest/types": "^26.1.0",
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "collect-v8-coverage": "^1.0.0"
+          }
+        },
+        "@jest/transform": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.1.0.tgz",
+          "integrity": "sha512-ICPm6sUXmZJieq45ix28k0s+d/z2E8CHDsq+WwtWI6kW8m7I8kPqarSEcUN86entHQ570ZBRci5OWaKL0wlAWw==",
+          "dev": true,
+          "requires": {
+            "@babel/core": "^7.1.0",
+            "@jest/types": "^26.1.0",
+            "babel-plugin-istanbul": "^6.0.0",
+            "chalk": "^4.0.0",
+            "convert-source-map": "^1.4.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "graceful-fs": "^4.2.4",
+            "jest-haste-map": "^26.1.0",
+            "jest-regex-util": "^26.0.0",
+            "jest-util": "^26.1.0",
+            "micromatch": "^4.0.2",
+            "pirates": "^4.0.1",
+            "slash": "^3.0.0",
+            "source-map": "^0.6.1",
+            "write-file-atomic": "^3.0.0"
+          }
+        },
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "callsites": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+          "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+          "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "yargs": {
+          "version": "15.3.1",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+          "integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^6.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^4.1.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^4.2.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^18.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
+    },
     "jest-serializer": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-24.9.0.tgz",
       "integrity": "sha512-DxYipDr8OvfrKH3Kel6NdED3OXxjvxXZ1uIY2I9OFbGg+vUkkg7AGvi65qbhbWNPvDckXmzMPbK3u3HaDO49bQ=="
+    },
+    "jest-snapshot": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.1.0.tgz",
+      "integrity": "sha512-YhSbU7eMTVQO/iRbNs8j0mKRxGp4plo7sJ3GzOQ0IYjvsBiwg0T1o0zGQAYepza7lYHuPTrG5J2yDd0CE2YxSw==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0",
+        "@jest/types": "^26.1.0",
+        "@types/prettier": "^2.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^26.1.0",
+        "graceful-fs": "^4.2.4",
+        "jest-diff": "^26.1.0",
+        "jest-get-type": "^26.0.0",
+        "jest-haste-map": "^26.1.0",
+        "jest-matcher-utils": "^26.1.0",
+        "jest-message-util": "^26.1.0",
+        "jest-resolve": "^26.1.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^26.1.0",
+        "semver": "^7.3.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-util": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.1.0.tgz",
+      "integrity": "sha512-rNMOwFQevljfNGvbzNQAxdmXQ+NawW/J72dmddsK0E8vgxXCMtwQ/EH0BiWEIxh0hhMcTsxwAxINt7Lh46Uzbg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.4",
+        "is-ci": "^2.0.0",
+        "micromatch": "^4.0.2"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "jest-validate": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.1.0.tgz",
+      "integrity": "sha512-WPApOOnXsiwhZtmkDsxnpye+XLb/tUISP+H6cHjfUIXvlG+eKwP+isnivsxlHCPaO9Q5wvbhloIBkdF3qUn+Nw==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "camelcase": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^26.0.0",
+        "leven": "^3.1.0",
+        "pretty-format": "^26.1.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "camelcase": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
+          "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "jest-watch-typeahead": {
       "version": "0.4.2",
@@ -15432,6 +19109,126 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
     },
+    "jsdom": {
+      "version": "16.2.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.2.2.tgz",
+      "integrity": "sha512-pDFQbcYtKBHxRaP55zGXCJWgFHkDAYbKcsXEK/3Icu9nKYZkutUXfLBwbD+09XDutkYSHcgfQLZ0qvpAAm9mvg==",
+      "dev": true,
+      "requires": {
+        "abab": "^2.0.3",
+        "acorn": "^7.1.1",
+        "acorn-globals": "^6.0.0",
+        "cssom": "^0.4.4",
+        "cssstyle": "^2.2.0",
+        "data-urls": "^2.0.0",
+        "decimal.js": "^10.2.0",
+        "domexception": "^2.0.1",
+        "escodegen": "^1.14.1",
+        "html-encoding-sniffer": "^2.0.1",
+        "is-potential-custom-element-name": "^1.0.0",
+        "nwsapi": "^2.2.0",
+        "parse5": "5.1.1",
+        "request": "^2.88.2",
+        "request-promise-native": "^1.0.8",
+        "saxes": "^5.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^3.0.1",
+        "w3c-hr-time": "^1.0.2",
+        "w3c-xmlserializer": "^2.0.0",
+        "webidl-conversions": "^6.0.0",
+        "whatwg-encoding": "^1.0.5",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0",
+        "ws": "^7.2.3",
+        "xml-name-validator": "^3.0.0"
+      },
+      "dependencies": {
+        "cssom": {
+          "version": "0.4.4",
+          "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.4.4.tgz",
+          "integrity": "sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==",
+          "dev": true
+        },
+        "data-urls": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+          "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0"
+          }
+        },
+        "domexception": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domexception/-/domexception-2.0.1.tgz",
+          "integrity": "sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==",
+          "dev": true,
+          "requires": {
+            "webidl-conversions": "^5.0.0"
+          },
+          "dependencies": {
+            "webidl-conversions": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+              "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+              "dev": true
+            }
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
+          "integrity": "sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==",
+          "dev": true,
+          "requires": {
+            "whatwg-encoding": "^1.0.5"
+          }
+        },
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        },
+        "saxes": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
+          "integrity": "sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==",
+          "dev": true,
+          "requires": {
+            "xmlchars": "^2.2.0"
+          }
+        },
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "w3c-xmlserializer": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
+          "integrity": "sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==",
+          "dev": true,
+          "requires": {
+            "xml-name-validator": "^3.0.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+          "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -15474,6 +19271,23 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
       "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
+    },
+    "json5": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+      "integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "dev": true
+        }
+      }
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -15718,6 +19532,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
       "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
+    },
+    "leven": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+      "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+      "dev": true
     },
     "levenary": {
       "version": "1.1.1",
@@ -15969,6 +19789,12 @@
         }
       }
     },
+    "make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true
+    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -16159,6 +19985,11 @@
             "@types/react": "*"
           }
         },
+        "deepmerge": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.3.0.tgz",
+          "integrity": "sha512-GRQOafGHwMHpjPx9iCvTgpu9NojZ49q794EEL94JVEw6VaeA8XTUyBKvAkOOjBX9oJNiV6G3P+T+tihFjo2TqA=="
+        },
         "dom-helpers": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
@@ -16271,114 +20102,13 @@
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
     },
     "micromatch": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-      "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-      "optional": true,
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+      "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+      "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "braces": "^2.3.1",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "extglob": "^2.0.4",
-        "fragment-cache": "^0.2.1",
-        "kind-of": "^6.0.2",
-        "nanomatch": "^1.2.9",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.2"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "optional": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "optional": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "optional": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "optional": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "optional": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "kind-of": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-          "optional": true
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "optional": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
+        "braces": "^3.0.1",
+        "picomatch": "^2.0.5"
       }
     },
     "miller-rabin": {
@@ -16756,6 +20486,14 @@
         "which": "1"
       },
       "dependencies": {
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        },
         "semver": {
           "version": "5.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
@@ -17409,6 +21147,12 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.3",
@@ -18564,6 +22308,97 @@
       "requires": {
         "renderkid": "^2.0.1",
         "utila": "~0.4"
+      }
+    },
+    "pretty-format": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.1.0.tgz",
+      "integrity": "sha512-GmeO1PEYdM+non4BKCj+XsPJjFOJIPnsLewqhDVoqY1xo0yNmDas7tC2XwpMrRAHR3MaE2hPo37deX5OisJ2Wg==",
+      "dev": true,
+      "requires": {
+        "@jest/types": "^26.1.0",
+        "ansi-regex": "^5.0.0",
+        "ansi-styles": "^4.0.0",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "@jest/types": {
+          "version": "26.1.0",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.1.0.tgz",
+          "integrity": "sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==",
+          "dev": true,
+          "requires": {
+            "@types/istanbul-lib-coverage": "^2.0.0",
+            "@types/istanbul-reports": "^1.1.1",
+            "@types/yargs": "^15.0.0",
+            "chalk": "^4.0.0"
+          }
+        },
+        "@types/yargs": {
+          "version": "15.0.5",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
+          "integrity": "sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==",
+          "dev": true,
+          "requires": {
+            "@types/yargs-parser": "*"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "dev": true,
+          "requires": {
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "private": {
@@ -22247,9 +26082,10 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
-      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
       "requires": {
         "glob": "^7.1.3"
       }
@@ -22262,6 +26098,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rsvp": {
+      "version": "4.8.5",
+      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
+      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
     },
     "run-async": {
       "version": "2.4.0",
@@ -22304,6 +26146,134 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sane": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sane/-/sane-4.1.0.tgz",
+      "integrity": "sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==",
+      "dev": true,
+      "requires": {
+        "@cnakazawa/watch": "^1.0.3",
+        "anymatch": "^2.0.0",
+        "capture-exit": "^2.0.0",
+        "exec-sh": "^0.3.2",
+        "execa": "^1.0.0",
+        "fb-watchman": "^2.0.0",
+        "micromatch": "^3.1.4",
+        "minimist": "^1.1.1",
+        "walker": "~1.0.5"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+          "dev": true,
+          "requires": {
+            "arr-flatten": "^1.1.0",
+            "array-unique": "^0.3.2",
+            "extend-shallow": "^2.0.1",
+            "fill-range": "^4.0.0",
+            "isobject": "^3.0.1",
+            "repeat-element": "^1.1.2",
+            "snapdragon": "^0.8.1",
+            "snapdragon-node": "^2.0.1",
+            "split-string": "^3.0.2",
+            "to-regex": "^3.0.1"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "fill-range": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+          "dev": true,
+          "requires": {
+            "extend-shallow": "^2.0.1",
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1",
+            "to-regex-range": "^2.1.0"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+              "dev": true,
+              "requires": {
+                "is-extendable": "^0.1.0"
+              }
+            }
+          }
+        },
+        "is-number": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+          "dev": true,
+          "requires": {
+            "kind-of": "^3.0.2"
+          },
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+              "dev": true,
+              "requires": {
+                "is-buffer": "^1.1.5"
+              }
+            }
+          }
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "dev": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          }
+        },
+        "to-regex-range": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+          "dev": true,
+          "requires": {
+            "is-number": "^3.0.0",
+            "repeat-string": "^1.6.1"
+          }
+        }
+      }
     },
     "sanitize.css": {
       "version": "10.0.0",
@@ -23475,6 +27445,12 @@
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
+    "strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true
+    },
     "strip-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
@@ -23550,6 +27526,33 @@
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "supports-hyperlinks": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-2.1.0.tgz",
+      "integrity": "sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0",
+        "supports-color": "^7.0.0"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
     },
     "svg-parser": {
@@ -23693,6 +27696,33 @@
         }
       }
     },
+    "terminal-link": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
+      "integrity": "sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^4.2.1",
+        "supports-hyperlinks": "^2.0.0"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+          "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.11.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+          "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+          "dev": true
+        }
+      }
+    },
     "terser": {
       "version": "4.6.13",
       "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.13.tgz",
@@ -23802,6 +27832,17 @@
             "has-flag": "^4.0.0"
           }
         }
+      }
+    },
+    "test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "requires": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
       }
     },
     "text-table": {
@@ -23927,6 +27968,23 @@
         }
       }
     },
+    "tr46": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+      "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+          "dev": true
+        }
+      }
+    },
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -23946,6 +28004,48 @@
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
       "requires": {
         "glob": "^7.1.2"
+      }
+    },
+    "ts-jest": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.1.0.tgz",
+      "integrity": "sha512-JbhQdyDMYN5nfKXaAwCIyaWLGwevcT2/dbqRPsQeh6NZPUuXjZQZEfeLb75tz0ubCIgEELNm6xAzTe5NXs5Y4Q==",
+      "dev": true,
+      "requires": {
+        "bs-logger": "0.x",
+        "buffer-from": "1.x",
+        "fast-json-stable-stringify": "2.x",
+        "json5": "2.x",
+        "lodash.memoize": "4.x",
+        "make-error": "1.x",
+        "micromatch": "4.x",
+        "mkdirp": "1.x",
+        "semver": "7.x",
+        "yargs-parser": "18.x"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
       }
     },
     "ts-pnp": {
@@ -24081,6 +28181,15 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "dev": true,
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
     },
     "typescript": {
       "version": "3.9.5",
@@ -24368,6 +28477,25 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
       "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
     },
+    "v8-to-istanbul": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-4.1.4.tgz",
+      "integrity": "sha512-Rw6vJHj1mbdK8edjR7+zuJrpDtKIgNdAvTSAcpYfgMIw+u2dPDntD3dgN4XQFLU2/fvFQdzj+EeSGfd/jnY5fQ==",
+      "dev": true,
+      "requires": {
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^1.6.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -24627,6 +28755,54 @@
           "optional": true,
           "requires": {
             "kind-of": "^3.0.2"
+          }
+        },
+        "micromatch": {
+          "version": "3.1.10",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+          "optional": true,
+          "requires": {
+            "arr-diff": "^4.0.0",
+            "array-unique": "^0.3.2",
+            "braces": "^2.3.1",
+            "define-property": "^2.0.2",
+            "extend-shallow": "^3.0.2",
+            "extglob": "^2.0.4",
+            "fragment-cache": "^0.2.1",
+            "kind-of": "^6.0.2",
+            "nanomatch": "^1.2.9",
+            "object.pick": "^1.3.0",
+            "regex-not": "^1.0.0",
+            "snapdragon": "^0.8.1",
+            "to-regex": "^3.0.2"
+          },
+          "dependencies": {
+            "extend-shallow": {
+              "version": "3.0.2",
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
+              "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
+              "optional": true,
+              "requires": {
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
+              }
+            },
+            "is-extendable": {
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+              "optional": true,
+              "requires": {
+                "is-plain-object": "^2.0.4"
+              }
+            },
+            "kind-of": {
+              "version": "6.0.3",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+              "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+              "optional": true
+            }
           }
         },
         "normalize-path": {
@@ -25764,14 +29940,33 @@
       }
     },
     "whatwg-fetch": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
+    },
+    "whatwg-url": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+      "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+      "dev": true,
+      "requires": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^2.0.2",
+        "webidl-conversions": "^5.0.0"
+      },
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+          "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==",
+          "dev": true
+        }
+      }
     },
     "which": {
       "version": "1.3.1",
@@ -26010,6 +30205,30 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "write-file-atomic": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
+      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+      "dev": true,
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "ws": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.0.tgz",
+      "integrity": "sha512-iFtXzngZVXPGgpTlP1rBqsUK82p9tKqsWRPg5L56egiljujJT3vGAYnHANvFxBieXrTFavhzhxW52jnaWV+w2w==",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-3.0.0.tgz",
+      "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
+      "dev": true
     },
     "xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "@types/draft-js": "^0.10.41",
     "@types/draftjs-to-html": "^0.8.0",
     "@types/html-to-draftjs": "^1.4.0",
+    "@types/jest": "^26.0.0",
     "@types/react-draft-wysiwyg": "^1.13.0",
     "@types/react-hamburger-menu": "0.0.3",
     "@types/react-html-parser": "^2.0.1",
@@ -116,6 +117,8 @@
     "@typescript-eslint/parser": "^3.2.0",
     "eslint": "^7.2.0",
     "eslint-plugin-react": "^7.20.0",
+    "jest": "^26.1.0",
+    "ts-jest": "^26.1.0",
     "tslint": "^6.1.2"
   }
 }

--- a/src/__mocks__/aws-amplify.ts
+++ b/src/__mocks__/aws-amplify.ts
@@ -1,0 +1,20 @@
+import { GraphQLResult } from '@aws-amplify/api/lib/types';
+
+const Amplify = {
+  configure: jest.fn(),
+};
+
+export const API = {
+  graphql: jest
+    .fn()
+    .mockImplementation((): Promise<GraphQLResult> => Promise.resolve({})),
+};
+
+export function graphqlOperation(query: any, variables?: Record<string, unknown>) {
+  return {
+    query,
+    variables,
+  };
+}
+
+export default Amplify;

--- a/src/components/RenderRouter/DataLoader.spec.ts
+++ b/src/components/RenderRouter/DataLoader.spec.ts
@@ -1,0 +1,661 @@
+import DataLoader from './DataLoader';
+import { API } from '__mocks__/aws-amplify';
+import { ModelSortDirection } from 'API';
+
+describe('series', () => {
+  test('return series data', async () => {
+    API.graphql.mockResolvedValue({
+      data: {
+        getSeries: {
+          id: 'series1',
+          videos: {
+            items: [{ id: 'video1' }],
+          },
+        },
+      },
+    });
+
+    const data = await DataLoader.getSeriesVideos({
+      class: 'videos',
+
+      selector: 'sameSeries',
+
+      id: 'series1',
+    });
+
+    expect(data).toEqual([{ id: 'video1' }]);
+  });
+
+  test('return no videos when the series is empty', async () => {
+    API.graphql.mockResolvedValue({});
+
+    const data = await DataLoader.getSeriesVideos({
+      class: 'videos',
+
+      selector: 'sameSeries',
+
+      id: 'series1',
+    });
+
+    expect(data).toEqual([]);
+  });
+
+  test('handle errors', async () => {
+    const err = new Error('test error');
+    API.graphql.mockRejectedValue(err);
+
+    await expect(
+      DataLoader.getSeriesVideos({
+        class: 'videos',
+
+        selector: 'sameSeries',
+
+        id: 'series1',
+      })
+    ).resolves.toEqual([]);
+  });
+});
+
+describe('videos', () => {
+  beforeEach(() => {
+    API.graphql.mockResolvedValue({
+      data: {
+        getVideoByVideoType: {
+          items: [
+            { id: 'video1', seriesTitle: 'series1' },
+            { id: 'video2', seriesTitle: 'series2' },
+          ],
+        },
+      },
+    });
+  });
+
+  test('return all video data', async () => {
+    const callback = jest.fn();
+    await DataLoader.getVideos(
+      {
+        class: 'videos',
+
+        selector: 'all',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([
+      { id: 'video1', seriesTitle: 'series1' },
+      { id: 'video2', seriesTitle: 'series2' },
+    ]);
+  });
+
+  test('filter video data', async () => {
+    const callback = jest.fn();
+    await DataLoader.getVideos(
+      {
+        class: 'videos',
+
+        selector: 'series1',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([
+      { id: 'video1', seriesTitle: 'series1' },
+    ]);
+  });
+
+  test('page through data', async () => {
+    API.graphql
+      .mockResolvedValueOnce({
+        data: {
+          getVideoByVideoType: {
+            items: [{ id: 'video1', seriesTitle: 'series1' }],
+            nextToken: 'abc',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          getVideoByVideoType: {
+            items: [{ id: 'video2', seriesTitle: 'series2' }],
+          },
+        },
+      });
+
+    const callback = jest.fn();
+    await DataLoader.getVideos(
+      {
+        class: 'videos',
+
+        selector: 'all',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([
+      { id: 'video1', seriesTitle: 'series1' },
+    ]);
+    expect(callback).toHaveBeenCalledWith([
+      { id: 'video2', seriesTitle: 'series2' },
+    ]);
+  });
+
+  test('handle errors', async () => {
+    API.graphql.mockRejectedValueOnce({
+      data: {
+        getVideoByVideoType: {
+          items: [{ id: 'video1', seriesTitle: 'series1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+    await DataLoader.getVideos(
+      {
+        class: 'videos',
+
+        selector: 'all',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([
+      { id: 'video1', seriesTitle: 'series1' },
+    ]);
+  });
+});
+
+describe('speakers', () => {
+  test('return all speaker data', async () => {
+    API.graphql.mockResolvedValueOnce({
+      data: {
+        listSpeakers: {
+          items: [{ id: 'speaker1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+    await DataLoader.getSpeakers(
+      {
+        class: 'speakers',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'speaker1' }]);
+  });
+
+  test('page through data', async () => {
+    API.graphql
+      .mockResolvedValueOnce({
+        data: {
+          listSpeakers: {
+            items: [{ id: 'speaker1' }],
+            nextToken: 'abc',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          listSpeakers: {
+            items: [{ id: 'speaker2' }],
+          },
+        },
+      });
+
+    const callback = jest.fn();
+    await DataLoader.getSpeakers(
+      {
+        class: 'speakers',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'speaker1' }]);
+    expect(callback).toHaveBeenCalledWith([{ id: 'speaker2' }]);
+  });
+
+  test('handle errors', async () => {
+    API.graphql.mockRejectedValue({
+      data: {
+        listSpeakers: {
+          items: [{ id: 'speaker1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+
+    await DataLoader.getSpeakers(
+      {
+        class: 'speakers',
+      },
+      callback
+    );
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});
+
+describe('blogs', () => {
+  test('return all blog data', async () => {
+    API.graphql.mockResolvedValueOnce({
+      data: {
+        getBlogByBlogStatus: {
+          items: [{ id: 'blog1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+    await DataLoader.getBlogs(
+      {
+        class: 'blogs',
+
+        status: 'published',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'blog1' }]);
+  });
+
+  test('page through data', async () => {
+    API.graphql
+      .mockResolvedValueOnce({
+        data: {
+          getBlogByBlogStatus: {
+            items: [{ id: 'blog1' }],
+            nextToken: 'abc',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          getBlogByBlogStatus: {
+            items: [{ id: 'blog2' }],
+          },
+        },
+      });
+
+    const callback = jest.fn();
+    await DataLoader.getBlogs(
+      {
+        class: 'blogs',
+
+        status: 'published',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'blog1' }]);
+    expect(callback).toHaveBeenCalledWith([{ id: 'blog2' }]);
+  });
+
+  test('handle errors', async () => {
+    API.graphql.mockRejectedValue({
+      data: {
+        getBlogByBlogStatus: {
+          items: [{ id: 'blog1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+
+    await DataLoader.getBlogs(
+      {
+        class: 'blogs',
+
+        status: 'published',
+      },
+      callback
+    );
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});
+
+describe('series by type', () => {
+  test('return all series data', async () => {
+    API.graphql.mockResolvedValueOnce({
+      data: {
+        getSeriesBySeriesType: {
+          items: [{ id: 'series1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+    await DataLoader.getSeriesByType(
+      {
+        class: 'series',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'series1' }]);
+  });
+
+  test('page through data', async () => {
+    API.graphql
+      .mockResolvedValueOnce({
+        data: {
+          getSeriesBySeriesType: {
+            items: [{ id: 'series1' }],
+            nextToken: 'abc',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          getSeriesBySeriesType: {
+            items: [{ id: 'series2' }],
+          },
+        },
+      });
+
+    const callback = jest.fn();
+    await DataLoader.getSeriesByType(
+      {
+        class: 'series',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).toHaveBeenCalledWith([{ id: 'series1' }]);
+    expect(callback).toHaveBeenCalledWith([{ id: 'series2' }]);
+  });
+
+  test('handle errors', async () => {
+    API.graphql.mockRejectedValue({
+      data: {
+        getSeriesBySeriesType: {
+          items: [{ id: 'series1' }],
+        },
+      },
+    });
+
+    const callback = jest.fn();
+
+    await DataLoader.getSeriesByType(
+      {
+        class: 'series',
+
+        sortOrder: ModelSortDirection.ASC,
+        subclass: 'Youtube',
+      },
+      callback
+    );
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});
+
+describe('staff', () => {
+  const staffPerson = {
+    FirstName: 'staff',
+    LastName: 'person',
+  };
+  const coordinatorPerson = {
+    FirstName: 'coordinator',
+    LastName: 'person',
+  };
+
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([staffPerson])))
+      .mockResolvedValueOnce(new Response(JSON.stringify([coordinatorPerson])));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockReset();
+  });
+
+  test('load staff', async () => {
+    const data = await DataLoader.loadStaff({
+      class: 'staff',
+
+      filterField: '',
+    });
+
+    expect(data).toEqual([staffPerson]);
+    expect(fetchSpy).toHaveBeenCalledWith('/static/data/staff.json');
+  });
+
+  test('load coordinators', async () => {
+    const data = await DataLoader.loadStaff({
+      class: 'staff',
+
+      filterField: 'sites',
+    });
+
+    expect(data).toEqual([staffPerson, coordinatorPerson]);
+    expect(fetchSpy).toHaveBeenCalledWith('/static/data/staff.json');
+    expect(fetchSpy).toHaveBeenCalledWith('/static/data/coordinators.json');
+  });
+
+  test('sorts lead pastors to the front', async () => {
+    fetchSpy.mockReset();
+    fetchSpy
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { LastName: 'xyz', Position: 'Teaching Pastor' },
+            { LastName: 'abc', Position: 'Music Pastor' },
+            { LastName: 'xyz', Position: 'Site Y Lead Pastor' },
+            { LastName: 'def', Position: 'Site X Lead Pastor' },
+          ])
+        )
+      )
+      .mockResolvedValueOnce(new Response('[]'));
+    const data = await DataLoader.loadStaff({
+      class: 'staff',
+
+      filterField: 'sites',
+    });
+
+    expect(data).toEqual([
+      { LastName: 'def', Position: 'Site X Lead Pastor' },
+      { LastName: 'xyz', Position: 'Site Y Lead Pastor' },
+      { LastName: 'abc', Position: 'Music Pastor' },
+      { LastName: 'xyz', Position: 'Teaching Pastor' },
+    ]);
+  });
+});
+
+describe('overseers', () => {
+  test('load overseers', async () => {
+    const overseer1 = {
+      FirstName: 'overseer',
+    };
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([overseer1])));
+
+    const data = await DataLoader.loadOverseers();
+
+    expect(data).toEqual([overseer1]);
+    expect(fetchSpy).toHaveBeenCalledWith('/static/data/overseers.json');
+  });
+});
+
+describe('events', () => {
+  const yesterday = new Date();
+  yesterday.setDate(yesterday.getDate() - 1);
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+
+  function fbDate(date: Date) {
+    return date.toISOString().replace('Z', '-0500');
+  }
+
+  const originalLocation = window.location;
+
+  beforeAll(() => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        hostname: 'https://themeetinghouse.com',
+      },
+    });
+  });
+
+  afterAll(() => {
+    window.location = originalLocation;
+  });
+
+  test('return future events', async () => {
+    const pastEvent = {
+      id: 'event1',
+      start_time: fbDate(yesterday),
+    };
+    const futureEvent = {
+      id: 'event2',
+      start_time: fbDate(tomorrow),
+    };
+
+    API.graphql.mockResolvedValueOnce({
+      data: {
+        getFBEvents: {
+          data: [pastEvent, futureEvent],
+        },
+      },
+    });
+
+    const data = await DataLoader.loadEvents({
+      class: 'events',
+
+      facebookEvents: null,
+    });
+
+    expect(data).toEqual([futureEvent]);
+  });
+
+  test('load multiple events', async () => {
+    const futureEvent1 = {
+      id: 'event1',
+      start_time: fbDate(tomorrow),
+    };
+    const futureEvent2 = {
+      id: 'event2',
+      start_time: fbDate(tomorrow),
+    };
+
+    API.graphql
+      .mockResolvedValueOnce({
+        data: {
+          getFBEvents: {
+            data: [futureEvent1],
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        data: {
+          getFBEvents: {
+            data: [futureEvent2],
+          },
+        },
+      });
+
+    const data = await DataLoader.loadEvents({
+      class: 'events',
+
+      facebookEvents: ['abc', 'def'],
+    });
+
+    expect(data).toEqual([futureEvent1, futureEvent2]);
+  });
+
+  test('sort events', async () => {
+    const tomorrowEvent = {
+      event: 'event1',
+      start_time: fbDate(tomorrow),
+    };
+    const nextDayDate = new Date(tomorrow);
+    nextDayDate.setDate(nextDayDate.getDate() + 1);
+    const nextDayEvent = {
+      event: 'event2',
+      start_time: fbDate(nextDayDate),
+    };
+    API.graphql.mockResolvedValueOnce({
+      data: {
+        getFBEvents: {
+          data: [nextDayEvent, tomorrowEvent],
+        },
+      },
+    });
+
+    const data = await DataLoader.loadEvents({
+      class: 'events',
+
+      facebookEvents: ['xyz'],
+    });
+
+    expect(data).toEqual([tomorrowEvent, nextDayEvent]);
+  });
+});
+
+describe('compassion', () => {
+  test('load compassion', async () => {
+    const compassion1 = {
+      id: 'compassion1',
+    };
+    const fetchSpy = jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValueOnce(new Response(JSON.stringify([compassion1])));
+
+    const data = await DataLoader.loadCompassion();
+
+    expect(data).toEqual([compassion1]);
+    expect(fetchSpy).toHaveBeenCalledWith('/static/data/compassion.json');
+  });
+});
+
+describe('locations', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(
+        new Response(JSON.stringify([{ id: 'oakville' }, { id: 'waterloo' }]))
+      );
+  });
+
+  test('return no location data without filter', async () => {
+    const data = await DataLoader.getLocations({
+      class: 'locations',
+    });
+
+    expect(data).toEqual([]);
+  });
+
+  test('filter location data', async () => {
+    const data = await DataLoader.getLocations({
+      class: 'locations',
+      filterField: 'id',
+      filterValue: 'waterloo',
+    });
+
+    expect(data).toEqual([{ id: 'waterloo' }]);
+  });
+});

--- a/src/components/RenderRouter/DataLoader.ts
+++ b/src/components/RenderRouter/DataLoader.ts
@@ -1,287 +1,493 @@
-import React from 'react';
 import * as queries from '../../graphql/queries';
 import * as customQueries from '../../graphql-custom/customQueries';
-import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api/lib/types';
+import { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api/lib/types';
 import Amplify, { API, graphqlOperation } from 'aws-amplify';
 import awsmobile from '../../aws-exports';
-import { RouteComponentProps } from 'react-router-dom';
+import {
+  GetSeriesQuery,
+  GetSeriesQueryVariables,
+  GetVideoByVideoTypeQuery,
+  GetVideoByVideoTypeQueryVariables,
+  ModelSortDirection,
+  ListSpeakersQuery,
+  ListSpeakersQueryVariables,
+  GetBlogByBlogStatusQuery,
+  GetBlogByBlogStatusQueryVariables,
+  GetSeriesBySeriesTypeQuery,
+  GetSeriesBySeriesTypeQueryVariables,
+  GetFbEventsQuery,
+  GetFbEventsQueryVariables,
+  GetCustomPlaylistQuery,
+  GetCustomPlaylistQueryVariables,
+} from 'API';
 
 Amplify.configure(awsmobile);
 
-
-interface Props extends RouteComponentProps {
-    content: any,
-    data: any,
-    dataLoaded(data: any): any
+export interface DataLoaderQuery {
+  class: string;
 }
-interface State {
-    content: any,
-    //  listData: any,
-    // overlayData: any,
-    // urlHistoryState: any
+
+export interface CustomPlaylistQuery extends DataLoaderQuery {
+  class: 'videos' | 'curious' | 'watch-page';
+
+  selector: 'custom-playlist';
+
+  playlist: string;
 }
-export default class DataLoader extends React.Component<Props, State> {
-    constructor(props: Props, state: State) {
-        super(props);
 
-        this.state = {
-            content: state.content,
-            // listData: state.listData,
-            //  overlayData: null,
-            //   urlHistoryState: window.history.state
-        }
+export interface VideoSeriesQuery extends DataLoaderQuery {
+  class: 'videos' | 'curious' | 'watch-page';
+
+  selector: string;
+
+  sortOrder: ModelSortDirection;
+  subclass: string;
+}
+
+export interface SeriesQuery extends DataLoaderQuery {
+  class: 'videos' | 'curious' | 'watch-page';
+
+  selector: 'sameSeries' | 'highlights';
+
+  id: string;
+}
+
+export interface SpeakerQuery extends DataLoaderQuery {
+  class: 'speakers';
+}
+
+export interface BlogQuery extends DataLoaderQuery {
+  class: 'blogs';
+
+  status: string;
+}
+
+export interface SeriesByTypeQuery extends DataLoaderQuery {
+  class: 'series';
+
+  sortOrder: ModelSortDirection;
+  subclass: string;
+}
+
+export interface StaffQuery extends DataLoaderQuery {
+  class: 'staff';
+
+  filterField: string;
+}
+
+export interface StaffData {
+  Staff?: boolean;
+  FirstName: string;
+  LastName: string;
+  Phone: string;
+  Position: string;
+  sites: string[];
+  Email: string;
+}
+
+export interface OverseerQuery extends DataLoaderQuery {
+  class: 'overseers';
+}
+
+export interface OverseerData {
+  FirstName: string;
+  LastName: string;
+  Position: string;
+  sites: string[];
+}
+
+export interface EventQuery extends DataLoaderQuery {
+  class: 'events';
+
+  facebookEvents: string[] | null;
+}
+
+export interface CompassionQuery extends DataLoaderQuery {
+  class: 'compassion';
+}
+
+export interface CompassionData {
+  id: number;
+  sites: string[];
+  name: string;
+  description: string;
+  website: string;
+  image: string;
+  imagealt: string;
+}
+
+export interface LocationQuery extends DataLoaderQuery {
+  class: 'locations';
+
+  filterField?: 'id';
+  filterValue?: string;
+}
+
+export interface LocationData {
+  id: string;
+  name: string;
+  pastorEmail: string;
+  location: {
+    longitude: number;
+    latitude: number;
+    address: string;
+  };
+  serviceTimes: string[];
+}
+
+type OnDataListener<T> = (data: T) => void;
+
+export type DataQuery =
+  | SpeakerQuery
+  | StaffQuery
+  | OverseerQuery
+  | EventQuery
+  | CompassionQuery
+  | VideoSeriesQuery
+  | SeriesQuery
+  | SeriesByTypeQuery
+  | BlogQuery
+  | CustomPlaylistQuery;
+
+export type SeriesData = NonNullable<
+  NonNullable<NonNullable<GetSeriesQuery['getSeries']>['videos']>['items']
+>[0];
+
+export type SeriesByTypeData = NonNullable<
+  NonNullable<GetSeriesBySeriesTypeQuery['getSeriesBySeriesType']>['items']
+>[0];
+
+export type VideoByVideoTypeData = NonNullable<
+  NonNullable<GetVideoByVideoTypeQuery['getVideoByVideoType']>['items']
+>[0];
+
+export type SpeakerData = NonNullable<
+  NonNullable<ListSpeakersQuery['listSpeakers']>['items']
+>[0];
+
+export type BlogData = NonNullable<
+  NonNullable<GetBlogByBlogStatusQuery['getBlogByBlogStatus']>['items']
+>[0];
+
+export type EventData = NonNullable<
+  NonNullable<GetFbEventsQuery['getFBEvents']>['data']
+>[0];
+
+export type CustomPlaylistVideoData = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<GetCustomPlaylistQuery['getCustomPlaylist']>['videos']
+    >['items']
+  >[0]
+>['video'];
+
+function parseFBDate(date: string): Date {
+  return new Date(
+    date.substring(0, date.length - 2) + ':' + date.substring(date.length - 2)
+  );
+}
+
+export default class DataLoader {
+  static async getVideosCustomPlaylist(
+    query: CustomPlaylistQuery
+  ): Promise<CustomPlaylistVideoData[]> {
+    try {
+      const variables: GetCustomPlaylistQueryVariables = {
+        id: query.playlist,
+      };
+      const getCustomPlaylist = (await API.graphql({
+        query: customQueries.getCustomPlaylist,
+        variables,
+        authMode: GRAPHQL_AUTH_MODE.API_KEY,
+      })) as GraphQLResult<GetCustomPlaylistQuery>;
+      console.log('Success queries.getCustomPlaylist: ' + getCustomPlaylist);
+      console.log(getCustomPlaylist);
+      const loadedVideos: CustomPlaylistVideoData[] = [];
+      for (const item of getCustomPlaylist.data?.getCustomPlaylist?.videos
+        ?.items ?? []) {
+        loadedVideos.push(item?.video ?? null);
+      }
+      console.log(loadedVideos);
+      return loadedVideos;
+    } catch (e) {
+      console.error(e);
     }
-    /* componentDidUpdate(prevProps: Props, prevState: State) {
-         if (prevState.listData !== this.state.listData)
-             this.props.dataLoaded(this.state.listData)
-         console.log(prevProps)
-     }*/
+    return [];
+  }
 
-    async getVideosCustomPlaylist(nextToken: any): Promise<void> {
-        try {
-            const getCustomPlaylist: any = await API.graphql({
-                query: customQueries.getCustomPlaylist,
-                variables: { nextToken: nextToken, limit: 20, id: this.state.content.playlist },
-                authMode: GRAPHQL_AUTH_MODE.API_KEY
-            });
-            console.log("Success queries.getCustomPlaylist: " + getCustomPlaylist)
-            console.log(getCustomPlaylist)
-            const loadedVideos: any = []
-            for (const item of getCustomPlaylist.data.getCustomPlaylist.videos.items) {
-                loadedVideos.push(item.video)
-            }
-            console.log(loadedVideos)
-            this.props.dataLoaded(loadedVideos)
-            if (getCustomPlaylist.data.getCustomPlaylist.videos.nextToken != null)
-                this.getVideosCustomPlaylist(getCustomPlaylist.data.getCustomPlaylist.videos.nextToken)
-        } catch (e) {
-            console.error(e)
+  static async getSeriesVideos(query: SeriesQuery): Promise<SeriesData[]> {
+    const variables: GetSeriesQueryVariables = {
+      id: query.id,
+    };
+    const getSeries = API.graphql({
+      query: customQueries.getSeries,
+      variables: variables,
+      authMode: GRAPHQL_AUTH_MODE.API_KEY,
+    }) as Promise<GraphQLResult<GetSeriesQuery>>;
+
+    try {
+      const json = await getSeries;
+      console.debug('Success queries.getSeries: ' + json);
+      console.debug(json);
+      return json.data?.getSeries?.videos?.items ?? [];
+    } catch (e) {
+      console.error(e);
+    }
+    return [];
+  }
+
+  static async getVideos(
+    query: VideoSeriesQuery,
+    dataLoaded: OnDataListener<VideoByVideoTypeData[]>,
+    nextToken: string | null = null
+  ): Promise<void> {
+    const variables: GetVideoByVideoTypeQueryVariables = {
+      nextToken: nextToken,
+      sortDirection: query.sortOrder,
+      limit: 20,
+      videoTypes: query.subclass,
+      publishedDate: { lt: 'a' },
+    };
+    const getVideoByVideoType = API.graphql({
+      query: customQueries.getVideoByVideoType,
+      variables,
+      authMode: GRAPHQL_AUTH_MODE.API_KEY,
+    }) as Promise<GraphQLResult<GetVideoByVideoTypeQuery>>;
+    try {
+      const json = await getVideoByVideoType;
+      console.debug('Success queries.getVideoByVideoType: ' + json);
+      console.debug(json);
+      const items = json?.data?.getVideoByVideoType?.items ?? [];
+      if (query.selector === 'all') {
+        dataLoaded(items);
+      } else {
+        dataLoaded(
+          items.filter((item) => item?.seriesTitle === query.selector)
+        );
+      }
+      if (json?.data?.getVideoByVideoType?.nextToken) {
+        await this.getVideos(
+          query,
+          dataLoaded,
+          json.data.getVideoByVideoType.nextToken
+        );
+      }
+    } catch (e) {
+      console.error({ 'Error: ': e });
+      if (query.selector === 'all') {
+        if (e.data) {
+          dataLoaded(e.data.getVideoByVideoType.items);
         }
-    } 
-
-    getVideosSameSeries(nextToken: any, id: string) {
-        const getSeries: any = API.graphql({
-            query: customQueries.getSeries,
-            variables: { nextToken: nextToken, sortDirection: this.state.content.sortOrder, limit: 20, id: id },
-            authMode: GRAPHQL_AUTH_MODE.API_KEY
-        });
-        getSeries.then((json: any) => {
-            console.log("Success queries.getSeries: " + json);
-            console.log(json)
-            this.props.dataLoaded(
-                json.data.getSeries.videos.items
+      } else {
+        if (e.data) {
+          dataLoaded(
+            e.data.getVideoByVideoType.items.filter(
+              (item: any) => item.seriesTitle === query.selector
             )
-            if (json.data.getSeries.nextToken != null)
-                this.getVideosSameSeries(json.data.getSeries.nextToken, id)
-        }).catch((e: any) => { console.log(e) })
-    }
-    getVideos(nextToken: any) {
-        const getVideoByVideoType: any = API.graphql({
-            query: customQueries.getVideoByVideoType,
-            variables: { nextToken: nextToken, sortDirection: this.state.content.sortOrder, limit: 20, videoTypes: this.state.content.subclass, publishedDate: { lt: "a" } },
-            authMode: GRAPHQL_AUTH_MODE.API_KEY
-        });
-        getVideoByVideoType.then((json: any) => {
-            console.log("Success queries.getVideoByVideoType: " + json);
-            console.log(json)
-            if (this.state.content.selector === "all") {
-                this.props.dataLoaded(
-                    json.data.getVideoByVideoType.items
-                )
-            } else {
-                this.props.dataLoaded(
-                    json.data.getVideoByVideoType.items.filter((item: any) => item.seriesTitle === this.state.content.selector)
-                )
-            }
-            if (json.data.getVideoByVideoType.nextToken != null)
-                this.getVideos(json.data.getVideoByVideoType.nextToken)
-
-        }).catch((e: any) => {
-            console.log({ "Error: ": e })
-            if (this.state.content.selector === "all") {
-                if (e.data) {
-                    this.props.dataLoaded(
-                        e.data.getVideoByVideoType.items
-                    )
-                }
-            }
-            else {
-                if (e.data)
-                    this.props.dataLoaded(
-                        e.data.getVideoByVideoType.items.filter((item: any) => item.seriesTitle === this.state.content.selector)
-                    )
-            }
-            if (e.data)
-                if (e.data.getVideoByVideoType.nextToken != null)
-                    this.getVideos(e.data.getVideoByVideoType.nextToken)
-        })
-    }
-    getSpeakers(nextToken: any) {
-        const listSpeakers: any = API.graphql(graphqlOperation(queries.listSpeakers, { nextToken: nextToken, sortOrder: this.state.content.sortOrder, limit: 20 }));
-        listSpeakers.then((json: any) => {
-            console.log("Success queries.listSpeakers: " + json);
-            console.log(json)
-            this.props.dataLoaded(
-                json.data.listSpeakers.items
-            )
-            if (json.data.listSpeakers.nextToken != null)
-                this.getSpeakers(json.data.listSpeakers.nextToken)
-
-        }).catch((e: any) => { console.log(e) })
-    }
-    getBlogs(nextToken: any) {
-        const getBlogByBlogStatus: any = API.graphql(graphqlOperation(queries.getBlogByBlogStatus, { nextToken: nextToken, blogStatus: this.state.content.status, sortDirection: this.state.content.sortOrder, limit: 200 }));
-        getBlogByBlogStatus.then((json: any) => {
-            console.log("Success queries.getBlogByBlogStatus: " + json);
-            console.log(json)
-            this.props.dataLoaded(
-                json.data.getBlogByBlogStatus.items
-            )
-            if (json.data.getBlogByBlogStatus.nextToken != null)
-                this.getBlogs(json.data.getBlogByBlogStatus.nextToken)
-
-        }).catch((e: any) => { console.log(e) })
-    }
-    getSeries(nextToken: any) {
-        const getSeriesBySeriesType: any = API.graphql({
-            query: customQueries.getSeriesBySeriesType,
-            variables: { nextToken: nextToken, sortDirection: this.state.content.sortOrder, limit: 50, seriesType: this.state.content.subclass, publishedDate: { lt: "a" } },
-            authMode: GRAPHQL_AUTH_MODE.API_KEY
-        });
-        getSeriesBySeriesType.then((json: any) => {
-            console.log({ "Success queries.getSeriesBySeriesType": json });
-            this.props.dataLoaded(json.data.getSeriesBySeriesType.items)
-            if (json.data.getSeriesBySeriesType.nextToken != null)
-                this.getSeries(json.data.getSeriesBySeriesType.nextToken)
-
-        }).catch((e: any) => { console.log(e) })
-    }
-    sortStaff(list: any) {
-        return list.sort((a: any, b: any) => {
-            if (a.Position.includes("Lead Pastor") && b.Position.includes("Lead Pastor"))
-                return a.lastName - b.lastName;
-            else if (a.Position.includes("Lead Pastor"))
-                return -1;
-            else if (b.Position.includes("Lead Pastor"))
-                return 1;
-            else
-                return a.lastName - b.lastName
-        })
-    }
-    getEvents(item: any) {
-        const getFbEvents: any = API.graphql({
-            query: queries.getFbEvents,
-            variables: { pageId: item },
-            authMode: GRAPHQL_AUTH_MODE.API_KEY
-        });
-        getFbEvents.then((json: any) => {
-            console.log("Success queries.getFBEvents: " + json);
-            console.log(json)
-            this.props.dataLoaded(this.filterEvents(json.data.getFBEvents.data).sort((a: any, b: any) => {
-                const a_time: Date = new Date(a.start_time.substring(0, a.start_time.length - 2) + ":" + a.start_time.substring(a.start_time.length - 2))
-                const b_time: Date = new Date(b.start_time.substring(0, b.start_time.length - 2) + ":" + b.start_time.substring(b.start_time.length - 2))
-                return a_time > b_time;
-            }))
-
-        }).catch((e: any) => { console.log(e) })
-    }
-    filterEvents(items: any) {
-        if (window.location.hostname === "localhost")
-            return items;
-        else
-            return items.filter((item: any) => {
-                const start_date = new Date(item.start_time.substring(0, item.start_time.length - 2) + ":" + item.start_time.substring(item.start_time.length - 2))
-                return (new Date() < start_date)
-            })
-    }
-    loadData() {
-        if (this.state.content.class === "videos" || this.state.content.class === "curious" || this.state.content.class === "watch-page") {
-            switch (this.state.content.selector) {
-                case "sameSeries":
-                    this.getVideosSameSeries(null, this.props.data.series.id)
-                    break;
-                case "highlights":
-                    this.getVideosSameSeries(null, "adult-sunday-shortcut-" + this.props.data.series.id)
-                    break;
-                case "custom-playlist":
-                    this.getVideosCustomPlaylist(null)
-                    break;
-                default:
-                    this.getVideos(null)
-            }
+          );
         }
-        else if (this.state.content.class === "speakers") {
-            this.getSpeakers(null)
+      }
+      if (e.data) {
+        if (e.data.getVideoByVideoType.nextToken) {
+          await this.getVideos(
+            query,
+            dataLoaded,
+            e.data.getVideoByVideoType.nextToken
+          );
         }
-        else if (this.state.content.class === "blogs") {
-            this.getBlogs(null)
-        }
-        else if (this.state.content.class === "series") {
-            this.getSeries(null)
-        }
-        else if (this.state.content.class === "staff") {
-            fetch('/static/data/staff.json').then(function (response) {
-                return response.json();
-            })
-                .then((myJson) => {
-                    if (this.state.content.filterField === "sites") {
-                        fetch('/static/data/coordinators.json').then(function (response) {
-                            return response.json();
-                        }).then((myJson2) => {
-                            this.props.dataLoaded(this.sortStaff(myJson).concat(myJson2))
-                        })
-
-                    }
-                    else {
-                        this.props.dataLoaded(myJson);
-                    }
-                })
-
-        }
-        else if (this.state.content.class === "overseers") {
-            fetch('/static/data/overseers.json').then(function (response) {
-                return response.json();
-            })
-                .then((myJson) => {
-                    this.props.dataLoaded(myJson);
-                })
-
-        }
-        else if (this.state.content.class === "events") {
-            if (this.state.content.facebookEvents != null) {
-                this.state.content.facebookEvents.forEach((item2: any) => {
-                    this.getEvents(item2)
-                })
-            }
-            else {
-                this.getEvents("155800937784104")
-            }
-
-        }
-        else if (this.state.content.class === "compassion") {
-            fetch('/static/data/compassion.json').then(function (response) {
-                return response.json();
-            })
-                .then((myJson) => {
-                    this.props.dataLoaded(myJson);
-                })
-
-        }
-        else if (this.state.content.class === "locations") {
-            fetch('/static/data/locations.json').then(function (response) {
-                return response.json();
-            })
-                .then((myJson) => {
-                    this.props.dataLoaded(myJson.filter((item: any) => {
-                        return item[this.state.content.filterField] === this.state.content.filterValue
-                    })
-                    )
-                }
-                )
-
-        }
+      }
     }
-    render() {
-        return null
+  }
+
+  static async getSpeakers(
+    query: SpeakerQuery,
+    dataLoaded: OnDataListener<SpeakerData[]>,
+    nextToken: string | null = null
+  ): Promise<void> {
+    const variables: ListSpeakersQueryVariables = {
+      nextToken: nextToken,
+      limit: 20,
+    };
+    const listSpeakers = API.graphql(
+      graphqlOperation(queries.listSpeakers, variables)
+    ) as Promise<GraphQLResult<ListSpeakersQuery>>;
+    try {
+      const json = await listSpeakers;
+      console.debug('Success queries.listSpeakers: ' + json);
+      console.debug(json);
+
+      dataLoaded(json?.data?.listSpeakers?.items ?? []);
+
+      const nextToken = json?.data?.listSpeakers?.nextToken;
+      if (nextToken) {
+        await this.getSpeakers(query, dataLoaded, nextToken);
+      }
+    } catch (e) {
+      console.error(e);
     }
+  }
+
+  static async getBlogs(
+    query: BlogQuery,
+    dataLoaded: OnDataListener<BlogData[]>,
+    nextToken: string | null = null
+  ): Promise<void> {
+    const vars: GetBlogByBlogStatusQueryVariables = {
+      nextToken: nextToken,
+      blogStatus: query.status,
+      limit: 200,
+    };
+    const getBlogByBlogStatus = API.graphql(
+      graphqlOperation(queries.getBlogByBlogStatus, vars)
+    ) as Promise<GraphQLResult<GetBlogByBlogStatusQuery>>;
+    try {
+      const json = await getBlogByBlogStatus;
+      console.debug('Success queries.getBlogByBlogStatus: ' + json);
+      console.debug(json);
+
+      dataLoaded(json?.data?.getBlogByBlogStatus?.items ?? []);
+
+      const nextToken = json?.data?.getBlogByBlogStatus?.nextToken;
+      if (nextToken) {
+        await this.getBlogs(query, dataLoaded, nextToken);
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  static async getSeriesByType(
+    query: SeriesByTypeQuery,
+    dataLoaded: OnDataListener<SeriesByTypeData[]>,
+    nextToken: string | null = null
+  ): Promise<void> {
+    const variables: GetSeriesBySeriesTypeQueryVariables = {
+      nextToken: nextToken,
+      sortDirection: query.sortOrder,
+      limit: 50,
+      seriesType: query.subclass,
+      startDate: { lt: 'a' },
+    };
+    const getSeriesBySeriesType = API.graphql({
+      query: customQueries.getSeriesBySeriesType,
+      variables,
+      authMode: GRAPHQL_AUTH_MODE.API_KEY,
+    }) as Promise<GraphQLResult<GetSeriesBySeriesTypeQuery>>;
+    try {
+      const json = await getSeriesBySeriesType;
+      console.debug({ 'Success queries.getSeriesBySeriesType': json });
+      dataLoaded(json?.data?.getSeriesBySeriesType?.items ?? []);
+      if (json?.data?.getSeriesBySeriesType?.nextToken) {
+        await this.getSeriesByType(
+          query,
+          dataLoaded,
+          json.data.getSeriesBySeriesType.nextToken
+        );
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  static sortStaff(list: StaffData[]): StaffData[] {
+    return list.sort((a, b) => {
+      if (a.Position.includes('Lead Pastor') && b.Position.includes('Lead Pastor'))
+        return a.LastName.localeCompare(b.LastName);
+      else if (a.Position.includes('Lead Pastor'))
+        return -1;
+      else if (b.Position.includes('Lead Pastor'))
+        return 1;
+      else
+        return a.LastName.localeCompare(b.LastName);
+    });
+  }
+
+  private static async getEvents(eventId: string): Promise<EventData[]> {
+    const variables: GetFbEventsQueryVariables = {
+      pageId: eventId,
+    };
+    const getFbEvents = API.graphql({
+      query: queries.getFbEvents,
+      variables,
+      authMode: GRAPHQL_AUTH_MODE.API_KEY,
+    }) as Promise<GraphQLResult<GetFbEventsQuery>>;
+    try {
+      const json = await getFbEvents;
+      console.debug('Success queries.getFBEvents: ' + json);
+      console.debug(json);
+      const events = json?.data?.getFBEvents?.data ?? [];
+      return this.filterEvents(events).sort((a, b) => {
+        if (!a?.start_time) {
+          return -1;
+        }
+        if (!b?.start_time) {
+          return 1;
+        }
+        const aTime = parseFBDate(a.start_time);
+        const bTime = parseFBDate(b.start_time);
+        return aTime.valueOf() - bTime.valueOf();
+      });
+    } catch (e) {
+      console.error(e);
+      return [];
+    }
+  }
+
+  static filterEvents(events: EventData[]): EventData[] {
+    if (window.location.hostname === 'localhost')
+      return events;
+    else
+      return events.filter((item) => {
+        if (!item?.start_time) {
+          return false;
+        }
+        return new Date() < parseFBDate(item.start_time);
+      });
+  }
+
+  static async loadStaff(query: StaffQuery): Promise<StaffData[]> {
+    let response = await fetch('/static/data/staff.json');
+    const staff: StaffData[] = await response.json();
+    if (query.filterField === 'sites') {
+      response = await fetch('/static/data/coordinators.json');
+      const coordinators: StaffData[] = await response.json();
+      return this.sortStaff(staff).concat(coordinators);
+    } else {
+      return staff;
+    }
+  }
+
+  static async loadOverseers(): Promise<OverseerData[]> {
+    const response = await fetch('/static/data/overseers.json');
+    return response.json();
+  }
+
+  static async loadEvents(query: EventQuery): Promise<EventData[]> {
+    if (query.facebookEvents !== null) {
+      const events = await Promise.all(
+        query.facebookEvents.map((facebookEventQuery) =>
+          this.getEvents(facebookEventQuery)
+        )
+      );
+      return events.reduce((acc, events) => acc.concat(events), []);
+    } else {
+      return this.getEvents('155800937784104');
+    }
+  }
+
+  static async loadCompassion(): Promise<CompassionData[]> {
+    const response = await fetch('/static/data/compassion.json');
+    return response.json();
+  }
+
+  static async getLocations(query: LocationQuery): Promise<LocationData[]> {
+    const response = await fetch('/static/data/locations.json');
+    const data: LocationData[] = await response.json();
+    return data.filter((location) => {
+      if (!query.filterField) {
+        return false;
+      }
+      return location[query.filterField as 'id'] === query.filterValue;
+    });
+  }
 }

--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -6,353 +6,355 @@ import AddToCalendar from 'react-add-to-calendar';
 import PropTypes from "prop-types";
 import "./HeroItem.scss"
 import Select from 'react-select';
-import DataLoader from './DataLoader';
+import DataLoader, { LocationData, LocationQuery } from './DataLoader';
 import moment from 'moment';
 
 interface Props extends RouteComponentProps {
-    content: any
-    data: any
+  content: LocationQuery;
+  data: any;
 }
 interface State {
-    content: any,
-    locationData: any,
-    arrowOpacity: any
+  content: any;
+  locationData: LocationData[];
+  arrowOpacity: any;
 }
 class HeroItem extends React.Component<Props, State> {
-    static contextTypes = {
-        router: PropTypes.object,
-        history: PropTypes.object
-    }
-    dataLoader: DataLoader
+  static contextTypes = {
+    router: PropTypes.object,
+    history: PropTypes.object
+  }
 
-    constructor(props: Props, context: any) {
-        super(props, context);
-        this.state = {
-            content: props.content,
-            locationData: [],
-            arrowOpacity: 1
-        }
-        this.navigate = this.navigate.bind(this);
-        this.setData = this.setData.bind(this);
-        this.dataLoader = new DataLoader({ ...this.props, dataLoaded: (data: any) => { this.setData(data) } }, this.state)
+  constructor(props: Props, context: any) {
+    super(props, context);
+    this.state = {
+      content: props.content,
+      locationData: [],
+      arrowOpacity: 1
+    }
+    this.navigate = this.navigate.bind(this);
+    this.setData = this.setData.bind(this);
 
+  }
+  async componentDidMount() {
+    const query = this.props.content;
+    if (query.class === 'locations') {
+      const data = await DataLoader.getLocations(query);
+      this.setData(data);
     }
-    componentDidMount() {
+  }
 
-        this.dataLoader.loadData()
+  setData(data: LocationData[]) {
+    this.setState({
+      locationData: this.state.locationData.concat(data),
+    });
+  }
+  getCalendarEventForLocation(locationItem: LocationData) {
+    let nextSunday = (moment().day() === 0 ? moment().add(1, "week") : moment().day(0)).startOf("day");
+    let serviceHour = locationItem.serviceTimes[locationItem.serviceTimes.length - 1];
+    serviceHour = serviceHour.substr(0, serviceHour.indexOf(":"));
+    nextSunday = nextSunday.hour(+serviceHour);
+    const event = {
+      title: 'Church at The Meeting House',
+      description: 'Join us at The Meeting House on Sunday!',
+      location: locationItem.location.address,
+      startTime: nextSunday.format(),
+      endTime: moment(nextSunday).add(90, "minutes").format()
     }
-    setData(data: any) {
-        this.setState({
-            locationData: this.state.locationData.concat(data)
-        })
-    }
-    getCalendarEventForLocation(locationItem: any) {
-        let nextSunday = (moment().day() === 0 ? moment().add(1, "week") : moment().day(0)).startOf("day");
-        let serviceHour = locationItem.serviceTimes[locationItem.serviceTimes.length - 1];
-        serviceHour = serviceHour.substr(0, serviceHour.indexOf(":"));
-        nextSunday = nextSunday.hour(+serviceHour);
-        const event = {
-            title: 'Church at The Meeting House',
-            description: 'Join us at The Meeting House on Sunday!',
-            location: locationItem.location.address,
-            startTime: nextSunday.format(),
-            endTime: moment(nextSunday).add(90, "minutes").format()
-        }
-        return event;
-    }
+    return event;
+  }
 
-    locationChange(item: any) {
-        this.navigateTo(item.value)
-    }
-    navigate() {
-        this.props.history.push("spirituality", "as")
-        const unblock = this.props.history.block('Are you sure you want to leave this page?');
-        unblock();
+  locationChange(item: any) {
+    this.navigateTo(item.value)
+  }
+  navigate() {
+    this.props.history.push("spirituality", "as")
+    const unblock = this.props.history.block('Are you sure you want to leave this page?');
+    unblock();
 
+  }
+  navigateTo(location: any) {
+    if (location.includes("http")) {
+      window.location.href = location
+    } else {
+      this.props.history.push(location, "as")
+      const unblock = this.props.history.block('Are you sure you want to leave this page?');
+      unblock();
     }
-    navigateTo(location: any) {
-        if (location.includes("http")) {
-            window.location.href = location
-        } else {
-            this.props.history.push(location, "as")
-            const unblock = this.props.history.block('Are you sure you want to leave this page?');
-            unblock();
-        }
-    }
-    smoothScrollTo(endX: any, endY: any, duration: any) {
-        const startX = window.scrollX || window.pageXOffset,
-            startY = window.scrollY || window.pageYOffset,
-            distanceX = endX - startX,
-            distanceY = endY - startY,
-            startTime = new Date().getTime();
+  }
+  smoothScrollTo(endX: any, endY: any, duration: any) {
+    const startX = window.scrollX || window.pageXOffset,
+      startY = window.scrollY || window.pageYOffset,
+      distanceX = endX - startX,
+      distanceY = endY - startY,
+      startTime = new Date().getTime();
 
-        // Easing function
-        const easeInOutQuart = function (time: any, from: any, distance: any, duration: any) {
-            if ((time /= duration / 2) < 1) return distance / 2 * time * time * time * time + from;
-            return -distance / 2 * ((time -= 2) * time * time * time - 2) + from;
-        };
+    // Easing function
+    const easeInOutQuart = function (time: any, from: any, distance: any, duration: any) {
+      if ((time /= duration / 2) < 1) return distance / 2 * time * time * time * time + from;
+      return -distance / 2 * ((time -= 2) * time * time * time - 2) + from;
+    };
 
-        const timer = window.setInterval(function () {
-            const time = new Date().getTime() - startTime,
-                newX = easeInOutQuart(time, startX, distanceX, duration),
-                newY = easeInOutQuart(time, startY, distanceY, duration);
-            if (time >= duration) {
-                window.clearInterval(timer);
-            }
-            window.scrollTo(newX, newY);
-        }, 1000 / 60); // 60 fps
-    }
-    scrollToNextPage() {
-        const pos = window.outerHeight;
-        if ('scrollBehavior' in document.documentElement.style) { //Checks if browser supports scroll function
-            window.scroll({
-                top: pos,
-                left: 0,
-                behavior: 'smooth'
-            });
-        } else {
-            this.smoothScrollTo(0, pos, 500); //polyfill below
-        }
-
-    }
-    navigateUrl(to: string) {
-        window.location.href = to;
+    const timer = window.setInterval(function () {
+      const time = new Date().getTime() - startTime,
+        newX = easeInOutQuart(time, startX, distanceX, duration),
+        newY = easeInOutQuart(time, startY, distanceY, duration);
+      if (time >= duration) {
+        window.clearInterval(timer);
+      }
+      window.scrollTo(newX, newY);
+    }, 1000 / 60); // 60 fps
+  }
+  scrollToNextPage() {
+    const pos = window.outerHeight;
+    if ('scrollBehavior' in document.documentElement.style) { //Checks if browser supports scroll function
+      window.scroll({
+        top: pos,
+        left: 0,
+        behavior: 'smooth'
+      });
+    } else {
+      this.smoothScrollTo(0, pos, 500); //polyfill below
     }
 
-    navigateEmail(to: any) {
-        this.navigateUrl("mailto:" + to)
-    }
-    imgUrl(size: any) {
-        if (window.location.hostname === "localhost")
-            return "https://localhost:3006"
-        else if (window.location.hostname.includes("beta"))
-            return "https://beta.themeetinghouse.com/cache/" + size
-        else
-            return "https://www.themeetinghouse.com/cache/" + size
-    }
-    fadeIn(obj: any) {
+  }
+  navigateUrl(to: string) {
+    window.location.href = to;
+  }
 
-        obj.target.style.transition = "opacity 1s";
-        obj.target.style.opacity = "1";
-    }
-    downArrowScroll() {
-        //console.log(window.scrollY)
-        const downArrow = document.getElementById('downArrow')
-        if (downArrow)
-            downArrow.style.opacity = ((1 - (window.scrollY / 250))).toString()
-    }
+  navigateEmail(to: any) {
+    this.navigateUrl("mailto:" + to)
+  }
+  imgUrl(size: any) {
+    if (window.location.hostname === "localhost")
+      return "https://localhost:3006"
+    else if (window.location.hostname.includes("beta"))
+      return "https://beta.themeetinghouse.com/cache/" + size
+    else
+      return "https://www.themeetinghouse.com/cache/" + size
+  }
+  fadeIn(obj: any) {
 
-    renderEmailSignup() {
-        return (
-            <div>
-                <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
-                <div id="mc_embed_signup" className="signupContainer">
-                    <form action="https://themeetinghouse.us8.list-manage.com/subscribe/post?u=3c4d56c1d635f336d8656e9dd&amp;id=3cb55a9826"
-                        method="post" id="mc-embedded-subscribe-form"
-                        name="mc-embedded-subscribe-form" className="validate" target="_blank">
-                        <div className="emailDiv" aria-hidden="true">
-                            <input className="emailInput" type="text" name="b_3c4d56c1d635f336d8656e9dd_3cb55a9826" value="" />
-                        </div>
-                        <div id="mc_embed_signup_scroll" className="signupButtons">
-                            <div className="emailWrapper">
-                                <img className="contactIcon" alt="Contac Icon" src="/static/svg/Contact.svg"></img>
-                                <input type="email" name="EMAIL" className="email" id="mce-EMAIL" placeholder="email address" />
-                            </div>
-                            <input type="submit" value="Sign Me Up" name="subscribe" className="heroButton" id="mc-embedded-subscribe" />
-                        </div>
-                    </form>
-                </div>
+    obj.target.style.transition = "opacity 1s";
+    obj.target.style.opacity = "1";
+  }
+  downArrowScroll() {
+    //console.log(window.scrollY)
+    const downArrow = document.getElementById('downArrow')
+    if (downArrow)
+      downArrow.style.opacity = ((1 - (window.scrollY / 250))).toString()
+  }
+
+  renderEmailSignup() {
+    return (
+      <div>
+        <link href="//cdn-images.mailchimp.com/embedcode/horizontal-slim-10_7.css" rel="stylesheet" type="text/css" />
+        <div id="mc_embed_signup" className="signupContainer">
+          <form action="https://themeetinghouse.us8.list-manage.com/subscribe/post?u=3c4d56c1d635f336d8656e9dd&amp;id=3cb55a9826"
+            method="post" id="mc-embedded-subscribe-form"
+            name="mc-embedded-subscribe-form" className="validate" target="_blank">
+            <div className="emailDiv" aria-hidden="true">
+              <input className="emailInput" type="text" name="b_3c4d56c1d635f336d8656e9dd_3cb55a9826" value="" />
             </div>
-        )
-    }
+            <div id="mc_embed_signup_scroll" className="signupButtons">
+              <div className="emailWrapper">
+                <img className="contactIcon" alt="Contac Icon" src="/static/svg/Contact.svg"></img>
+                <input type="email" name="EMAIL" className="email" id="mce-EMAIL" placeholder="email address" />
+              </div>
+              <input type="submit" value="Sign Me Up" name="subscribe" className="heroButton" id="mc-embedded-subscribe" />
+            </div>
+          </form>
+        </div>
+      </div>
+    )
+  }
 
-    renderHeroImage(className: string) {
-        const image1 = this.state.content.image1[Math.floor(Math.random() * this.state.content.image1.length)];
-        let onLoad = (_: any) => { };
-        let style;
-        if (className === "heroImage") {
-            onLoad = item => this.fadeIn(item)
-            style = { opacity: 0 };
-        }
-        return (
-            image1.src.includes(".svg") ?
-                <img src={image1.src} alt={image1.alt} className={className} /> :
-                <img src={this.imgUrl(2560) + image1.src} alt={image1.alt} className={className}
-                    style={style} onLoad={onLoad}
-                    srcSet={this.imgUrl(320) + image1.src + " 320w," +
-                        this.imgUrl(480) + image1.src + " 480w," +
-                        this.imgUrl(640) + image1.src + " 640w," +
-                        this.imgUrl(1280) + image1.src + " 1280w," +
-                        this.imgUrl(1920) + image1.src + " 1920w," +
-                        this.imgUrl(2560) + image1.src + " 2560w"}
-                    sizes="(max-width: 320px) 320px,
+  renderHeroImage(className: string) {
+    const image1 = this.state.content.image1[Math.floor(Math.random() * this.state.content.image1.length)];
+    let onLoad = (_: any) => { };
+    let style;
+    if (className === "heroImage") {
+      onLoad = item => this.fadeIn(item)
+      style = { opacity: 0 };
+    }
+    return (
+      image1.src.includes(".svg") ?
+        <img src={image1.src} alt={image1.alt} className={className} /> :
+        <img src={this.imgUrl(2560) + image1.src} alt={image1.alt} className={className}
+          style={style} onLoad={onLoad}
+          srcSet={this.imgUrl(320) + image1.src + " 320w," +
+            this.imgUrl(480) + image1.src + " 480w," +
+            this.imgUrl(640) + image1.src + " 640w," +
+            this.imgUrl(1280) + image1.src + " 1280w," +
+            this.imgUrl(1920) + image1.src + " 1920w," +
+            this.imgUrl(2560) + image1.src + " 2560w"}
+          sizes="(max-width: 320px) 320px,
                         (max-width: 480px) 480px,
                         (max-width: 640px) 640px,
                         (max-width: 1280px) 1280px,
                         (max-width: 1920) 1920,
                         2560px"
-                />
-        )
+        />
+    )
+  }
+
+  render() {
+    window.onscroll = () => { this.downArrowScroll() }
+    if (this.state.content.style === "full") {
+      return (
+        <div className="headerItem heroItem" >
+          <div className="heroImageGradient" onClick={() => { this.scrollToNextPage() }}></div>
+          {this.renderHeroImage("heroImage")}
+          <div className="heroBlackBox" >
+            <h1 className="heroH1" >{this.state.content.header1}</h1>
+
+            {this.state.locationData.length === 1 ? <h2 className="heroH2">{this.state.locationData[0].location.address}</h2>
+              : this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
+            <hr className="heroHr"></hr>
+            <div className="heroText1" >{this.state.content.text1}</div>
+            <div className="heroText2" >{this.state.content.text2}</div>
+            <div className="heroText2" >{this.state.content.text3}</div>
+            <div className="heroText2" >{this.state.content.text4}</div>
+            <div className="heroText2" >{this.state.content.text5}</div>
+            <div className="heroText2" >{this.state.content.text6}</div>
+            <div className="heroText2" >{this.state.content.text7}</div>
+            {this.state.content.button1Text ? (<Button className="heroButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
+            {this.state.content.link1Text ? <div className="heroAContainer"><a className="heroBlackBoxA" href={this.state.content.link1Action}>{this.state.content.link1Text}</a></div> : null}
+            {
+              this.state.content.addToCalendar ?
+                this.state.locationData.length === 1 ?
+                  <div className="HeroAddToCalendarButtonContainer">
+                    <img className="SundaMorningIcon" src="/static/svg/Calendar-white.svg" alt="Calendar Icon" />
+                    <AddToCalendar buttonLabel="Add to Calendar" event={this.getCalendarEventForLocation(this.state.locationData[0])} ></AddToCalendar>
+                  </div>
+
+                  : null
+                : null
+            }
+            {this.state.content.contactPastor ?
+              this.state.locationData.length === 1 ? (
+                <a href={"mailto:" + this.state.locationData[0].pastorEmail}><button className="calendarButton"><img className="calendarImage" src="/static/svg/Contact-white.svg" alt="Contact Icon" />Contact the Pastor</button></a>)
+                : null
+              : null}
+            <br />
+
+          </div>
+          {this.state.content.showCovid ? <div className="covidButton"><Button onClick={() => { this.navigateTo("covid19") }} className="covidButtonDetail">COVID-19 Update</Button></div> : null}
+          <div><img id="downArrow" style={{ opacity: this.state.arrowOpacity, cursor: "pointer" }} src="/static/svg/DownArrow.svg" className="downarrow animated bounce" alt="Down Arrow" onClick={() => { this.scrollToNextPage() }} /> </div>
+
+        </div>
+
+      )
     }
+    else if (this.state.content.style === "partialNoFooter") {
 
-    render() {
-        window.onscroll = () => { this.downArrowScroll() }
-        if (this.state.content.style === "full") {
-            return (
-                <div className="headerItem heroItem" >
-                    <div className="heroImageGradient" onClick={() => { this.scrollToNextPage() }}></div>
-                    {this.renderHeroImage("heroImage")}
-                    <div className="heroBlackBox" >
-                        <h1 className="heroH1" >{this.state.content.header1}</h1>
+      return (
+        <div className="partialNoFooter" >
+          {this.renderHeroImage("partialNoFooterImage")}
+          <div className="partialNoFooterBox" >
+            <h1 className="heroH1" >{this.state.content.header1}</h1>
+            {this.state.content.header2 && <h2 className="heroH2" >{this.state.content.header2}</h2>}
+            <hr className="partialNoFooterBoxHr" ></hr>
+            <div className="heroText1">{this.state.content.text1}</div>
+            <div className="heroText1">{this.state.content.text2}</div>
+            <div className="heroText2">{this.state.content.text3}</div>
+            <div className="heroText2">{this.state.content.text4}</div>
+            <div className="heroText2">{this.state.content.text5}</div>
+            <div className="heroText2">{this.state.content.text6}</div>
+            <div className="heroText2">{this.state.content.text7}</div>
+            {this.state.content.showLocationSearch ? (
+              <div>
+                {this.state.locationData != null ?
+                  <Select onChange={(item) => { this.locationChange(item) }}
+                    styles={{
 
-                        {this.state.locationData.length === 1 ? <h2 className="heroH2">{this.state.locationData[0].location.address}</h2>
-                            : this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
-                        <hr className="heroHr"></hr>
-                        <div className="heroText1" >{this.state.content.text1}</div>
-                        <div className="heroText2" >{this.state.content.text2}</div>
-                        <div className="heroText2" >{this.state.content.text3}</div>
-                        <div className="heroText2" >{this.state.content.text4}</div>
-                        <div className="heroText2" >{this.state.content.text5}</div>
-                        <div className="heroText2" >{this.state.content.text6}</div>
-                        <div className="heroText2" >{this.state.content.text7}</div>
-                        {this.state.content.button1Text ? (<Button className="heroButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
-                        {this.state.content.link1Text ? <div className="heroAContainer"><a className="heroBlackBoxA" href={this.state.content.link1Action}>{this.state.content.link1Text}</a></div> : null}
-                        {
-                            this.state.content.addToCalendar ?
-                                this.state.locationData.length === 1 ?
-                                    <div className="HeroAddToCalendarButtonContainer">
-                                        <img className="SundaMorningIcon" src="/static/svg/Calendar-white.svg" alt="Calendar Icon" />
-                                        <AddToCalendar buttonLabel="Add to Calendar" event={this.getCalendarEventForLocation(this.state.locationData[0])} ></AddToCalendar>
-                                    </div>
-
-                                    : null
-                                : null
-                        }
-                        {this.state.content.contactPastor ?
-                            this.state.locationData.length === 1 ? (
-                                <a href={"mailto:" + this.state.locationData[0].pastorEmail}><button className="calendarButton"><img className="calendarImage" src="/static/svg/Contact-white.svg" alt="Contact Icon" />Contact the Pastor</button></a>)
-                                : null
-                            : null}
-                        <br />
-
-                    </div>
-                    {this.state.content.showCovid ? <div className="covidButton"><Button onClick={() => { this.navigateTo("covid19") }} className="covidButtonDetail">COVID-19 Update</Button></div> : null}
-                    <div><img id="downArrow" style={{ opacity: this.state.arrowOpacity, cursor: "pointer" }} src="/static/svg/DownArrow.svg" className="downarrow animated bounce" alt="Down Arrow" onClick={() => { this.scrollToNextPage() }} /> </div>
-
-                </div>
-
-            )
-        }
-        else if (this.state.content.style === "partialNoFooter") {
-
-            return (
-                <div className="partialNoFooter" >
-                    {this.renderHeroImage("partialNoFooterImage")}
-                    <div className="partialNoFooterBox" >
-                        <h1 className="heroH1" >{this.state.content.header1}</h1>
-                        {this.state.content.header2 && <h2 className="heroH2" >{this.state.content.header2}</h2>}
-                        <hr className="partialNoFooterBoxHr" ></hr>
-                        <div className="heroText1">{this.state.content.text1}</div>
-                        <div className="heroText1">{this.state.content.text2}</div>
-                        <div className="heroText2">{this.state.content.text3}</div>
-                        <div className="heroText2">{this.state.content.text4}</div>
-                        <div className="heroText2">{this.state.content.text5}</div>
-                        <div className="heroText2">{this.state.content.text6}</div>
-                        <div className="heroText2">{this.state.content.text7}</div>
-                        {this.state.content.showLocationSearch ? (
-                            <div>
-                                {this.state.locationData != null ?
-                                    <Select onChange={(item) => { this.locationChange(item) }}
-                                        styles={{
-
-                                            menuPortal: styles => ({ ...styles, zIndex: 999 }) //  >= dialog's z-index
-                                        }}
-                                        placeholder="Search for a church by city" className="partialNoFooterLocationDropDown"
-                                        options={this.state.locationData.map(
-                                            (item: any) => {
-                                                return { label: item.name, value: item.id }
-                                            }
-                                        ).sort((a: any, b: any) => {
-                                            return a.label.localeCompare(b.label)
-                                        })
-                                        }></Select>
-                                    : null}
-                            </div>) : null}
-                        {this.state.content.button1Text ? (<Button className="heroItemButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
-                        <a className="HeroItemButtonA" href={this.state.content.link1Action}>{this.state.content.link1Text}</a>
-                        {this.state.content.addToCalendar ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/svg/Calendar, Add To.svg" alt="Calendar Icon" />Add To Calendar</Button>) : null}
-                        {this.state.content.contactPastor ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/svg/Contact.svg" alt="Contact Icon" />Contact the Pastor</Button>) : null}
-                    </div>
-                </div>
-            )
-        }
-        else if (this.state.content.style === "partial") {
-
-            return (
-                <div className="headerItem divPartial" >
-                    {this.renderHeroImage("partial")}
-                    <div className="heroPartialBlackBox" >
-                        <h1 className="heroH1" >{this.state.content.header1}</h1>
-                        {this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
-                        <hr className="heroHr"></hr>
-                        <div className="heroText1" >{this.state.content.text1}</div>
-                        <div className="heroText2" >{this.state.content.text2}</div>
-                        <div className="heroText2" >{this.state.content.text3}</div>
-                        <div className="heroText2" >{this.state.content.text4}</div>
-                        <div className="heroText2" >{this.state.content.text5}</div>
-                        <div className="heroText2" >{this.state.content.text6}</div>
-                        <div className="heroText2" >{this.state.content.text7}</div>
-                        {this.state.content.showLocationSearch ? (
-                            <div>
-                                {this.state.locationData != null ?
-                                    <Select menuPortalTarget={document.querySelector('body')} X
-                                        styles={{
-
-                                            menuPortal: styles => ({ ...styles, zIndex: 999 }) //  >= dialog's z-index
-                                        }}
-                                        onChange={(item) => { this.locationChange(item) }}
-                                        placeholder="Search for a church by city" className="partialLocationDropDown"
-                                        options={this.state.locationData.map(
-                                            (item: any) => {
-                                                return { label: item.name, value: item.id }
-                                            }
-                                        ).sort((a: any, b: any) => {
-                                            return a.label.localeCompare(b.label)
-                                        })
-                                        }></Select>
-                                    : null}
-                            </div>) : null}
-                        {this.state.content.button1Text ? (<Button className="heroButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
-                        {this.state.content.link1Text ? <div className="heroAContainer"><a className="HeroItemA2" href={this.state.content.link1Action}>{this.state.content.link1Text}</a></div> : null}
-                        {this.state.content.addToCalendar ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/Calendar.png" alt="Calendar Icon" />Add To Calendar</Button>) : null}
-                        {this.state.content.contactPastor ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/Contact.png" alt="Contact Icon" />Contact the Pastor</Button>) : null}
-
-                    </div>
-
-                </div>
-            )
-        } else if (this.state.content.style === "connect") {
-            return (
-                <div className="partialConnect" >
-                    {this.renderHeroImage("partialConnectImage")}
-                    <div className="partialConnectBox" >
-                        <h1 className="heroH1" >{this.state.content.header1}</h1>
-                        {this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
-                        <hr className="heroHr"></hr>
-                        <div className="heroText1" >{this.state.content.text1}</div>
-                        <div className="heroText2" >{this.state.content.text2}</div>
-                        <div className="heroText2" >{this.state.content.text3}</div>
-                        <div className="heroText2" >{this.state.content.text4}</div>
-                        <div className="heroText2" >{this.state.content.text5}</div>
-                        <div className="heroText2" >{this.state.content.text6}</div>
-                        <div className="heroText2" >{this.state.content.text7}</div>
-                        {this.renderEmailSignup()}
-                    </div>
-                </div>
-            )
-        }
-        else return null
+                      menuPortal: styles => ({ ...styles, zIndex: 999 }) //  >= dialog's z-index
+                    }}
+                    placeholder="Search for a church by city" className="partialNoFooterLocationDropDown"
+                    options={this.state.locationData.map(
+                      (item: any) => {
+                        return { label: item.name, value: item.id }
+                      }
+                    ).sort((a: any, b: any) => {
+                      return a.label.localeCompare(b.label)
+                    })
+                    }></Select>
+                  : null}
+              </div>) : null}
+            {this.state.content.button1Text ? (<Button className="heroItemButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
+            <a className="HeroItemButtonA" href={this.state.content.link1Action}>{this.state.content.link1Text}</a>
+            {this.state.content.addToCalendar ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/svg/Calendar, Add To.svg" alt="Calendar Icon" />Add To Calendar</Button>) : null}
+            {this.state.content.contactPastor ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/svg/Contact.svg" alt="Contact Icon" />Contact the Pastor</Button>) : null}
+          </div>
+        </div>
+      )
     }
+    else if (this.state.content.style === "partial") {
+
+      return (
+        <div className="headerItem divPartial" >
+          {this.renderHeroImage("partial")}
+          <div className="heroPartialBlackBox" >
+            <h1 className="heroH1" >{this.state.content.header1}</h1>
+            {this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
+            <hr className="heroHr"></hr>
+            <div className="heroText1" >{this.state.content.text1}</div>
+            <div className="heroText2" >{this.state.content.text2}</div>
+            <div className="heroText2" >{this.state.content.text3}</div>
+            <div className="heroText2" >{this.state.content.text4}</div>
+            <div className="heroText2" >{this.state.content.text5}</div>
+            <div className="heroText2" >{this.state.content.text6}</div>
+            <div className="heroText2" >{this.state.content.text7}</div>
+            {this.state.content.showLocationSearch ? (
+              <div>
+                {this.state.locationData != null ?
+                  <Select menuPortalTarget={document.querySelector('body')} X
+                    styles={{
+
+                      menuPortal: styles => ({ ...styles, zIndex: 999 }) //  >= dialog's z-index
+                    }}
+                    onChange={(item) => { this.locationChange(item) }}
+                    placeholder="Search for a church by city" className="partialLocationDropDown"
+                    options={this.state.locationData.map(
+                      (item: any) => {
+                        return { label: item.name, value: item.id }
+                      }
+                    ).sort((a: any, b: any) => {
+                      return a.label.localeCompare(b.label)
+                    })
+                    }></Select>
+                  : null}
+              </div>) : null}
+            {this.state.content.button1Text ? (<Button className="heroButton" onClick={() => { this.navigateTo(this.state.content.button1Action) }}>{this.state.content.button1Text}</Button>) : null}
+            {this.state.content.link1Text ? <div className="heroAContainer"><a className="HeroItemA2" href={this.state.content.link1Action}>{this.state.content.link1Text}</a></div> : null}
+            {this.state.content.addToCalendar ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/Calendar.png" alt="Calendar Icon" />Add To Calendar</Button>) : null}
+            {this.state.content.contactPastor ? (<Button className="heroItemButton" onClick={this.navigate}><img src="/static/Contact.png" alt="Contact Icon" />Contact the Pastor</Button>) : null}
+
+          </div>
+
+        </div>
+      )
+    } else if (this.state.content.style === "connect") {
+      return (
+        <div className="partialConnect" >
+          {this.renderHeroImage("partialConnectImage")}
+          <div className="partialConnectBox" >
+            <h1 className="heroH1" >{this.state.content.header1}</h1>
+            {this.state.content.header2 && <h2 className="heroH2">{this.state.content.header2}</h2>}
+            <hr className="heroHr"></hr>
+            <div className="heroText1" >{this.state.content.text1}</div>
+            <div className="heroText2" >{this.state.content.text2}</div>
+            <div className="heroText2" >{this.state.content.text3}</div>
+            <div className="heroText2" >{this.state.content.text4}</div>
+            <div className="heroText2" >{this.state.content.text5}</div>
+            <div className="heroText2" >{this.state.content.text6}</div>
+            <div className="heroText2" >{this.state.content.text7}</div>
+            {this.renderEmailSignup()}
+          </div>
+        </div>
+      )
+    }
+    else return null
+  }
 }
 
 

--- a/src/components/RenderRouter/HomeChurchItem.tsx
+++ b/src/components/RenderRouter/HomeChurchItem.tsx
@@ -78,9 +78,7 @@ interface State {
   contactHomeChurchId: any,
 }
 
-export class ContentItem extends React.Component<Props, State>  {
-
-  dataLoader: DataLoader;
+export class ContentItem extends React.Component<Props, State> {
   selectControl: any;
   inputControl: any;
   homeChurchListScrollContainer: any;
@@ -104,16 +102,13 @@ export class ContentItem extends React.Component<Props, State>  {
       currentLatLng: DEFAULT_LAT_LNG,
       showContactModal: false,
       contactHomeChurchId: null,
-    }
+    };
 
-    this.dataLoader = new DataLoader({
-      ...this.props, data: {}, dataLoaded: (data: any) => {
-        data.sort((l1: any, l2: any) => l1.name.localeCompare(l2.name));
-        console.log("HomeChurchItem.constructor(): Got locations: %o", data);
-        this.setState({ locations: data });
-      }
-    }, { content: { class: "locations" } })
-    this.dataLoader.loadData();
+    DataLoader.getLocations({ class: 'locations' }).then((locations) => {
+      locations.sort((l1: any, l2: any) => l1.name.localeCompare(l2.name));
+      console.log('HomeChurchItem.constructor(): Got locations: %o', locations);
+      this.setState({ locations });
+    });
 
     if (this.state.content.class === "home-church") {
 

--- a/src/components/RenderRouter/ListItem.tsx
+++ b/src/components/RenderRouter/ListItem.tsx
@@ -1,105 +1,192 @@
 import React, { EventHandler, SyntheticEvent } from 'react';
-import PropTypes from "prop-types";
+import PropTypes from 'prop-types';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import VideoOverlay from '../VideoOverlay/VideoOverlay';
-import DataLoader from './DataLoader';
+import DataLoader, {
+  StaffData,
+  OverseerData,
+  EventData,
+  CompassionData,
+  DataQuery,
+  VideoByVideoTypeData,
+  SpeakerData,
+  BlogData,
+  SeriesData,
+  SeriesByTypeData,
+  SeriesQuery,
+  CustomPlaylistQuery,
+  CustomPlaylistVideoData,
+  VideoSeriesQuery,
+} from './DataLoader';
 import HorizontalScrollList from './HorizontalScrollList';
-import "./ListItem.scss";
+import './ListItem.scss';
 import format from 'date-fns/format';
 import Fireworks from 'fireworks-react';
 import Konami from 'react-konami-code';
 
 interface Props extends RouteComponentProps {
-  content: any,
-  data: any,
-  pageConfig: any
-
+  content: any;
+  data: any;
+  pageConfig: any;
 }
 interface State {
-  content: any,
-  listData: any,
-  overlayData: any,
-  urlHistoryState: any,
-  showChampion: any,
-  showMoreVideos: boolean,
-  numberOfVideos: number
+  content: DataQuery & {
+    style: string;
+    header1: string;
+    header2: string;
+    text1: string;
+
+    showEpisodeNumbers: boolean;
+    hovertag: string;
+  };
+  listData: ListData[];
+  overlayData: any;
+  urlHistoryState: any;
+  showChampion: any;
+  showMoreVideos: boolean;
+  numberOfVideos: number;
 }
+
+type VideoData = SeriesData | VideoByVideoTypeData | CustomPlaylistVideoData;
+
+type ListData =
+  | SpeakerData
+  | VideoData
+  | StaffData
+  | OverseerData
+  | EventData
+  | CompassionData
+  | SeriesByTypeData
+  | BlogData;
 
 class ListItem extends React.Component<Props, State> {
   static contextTypes = {
     router: PropTypes.object,
-    history: PropTypes.object
-  }
+    history: PropTypes.object,
+  };
   videoOverlayClose() {
     this.setState({
-      overlayData: null
-    })
-    window.history.pushState({}, "Videos", this.state.urlHistoryState)
-
+      overlayData: null,
+    });
+    window.history.pushState({}, 'Videos', this.state.urlHistoryState);
   }
   showYears(start: any, end: any) {
     if (start === null || end === null)
-      return null
+      return null;
     else
       if (new Date(start).getFullYear() === new Date(end).getFullYear())
-        return new Date(start).getFullYear() + " • "
+        return new Date(start).getFullYear() + ' • ';
       else
-        return new Date(start).getFullYear() + " - " + new Date(end).getFullYear() + " • "
+        return new Date(start).getFullYear() + ' - ' + new Date(end).getFullYear() + ' • ';
   }
   handleClick(data: any) {
     this.setState({
       overlayData: data,
-      urlHistoryState: window.location.href
-    })
+      urlHistoryState: window.location.href,
+    });
     if (data.series == null)
-      console.log({ "You need to create a series for:": data })
+      console.log({ 'You need to create a series for:': data });
     else
-      window.history.pushState({}, "Videos", "/videos/" + data.series.id + "/" + data.id)
+      window.history.pushState({}, 'Videos', '/videos/' + data.series.id + '/' + data.id);
   }
 
-  dataLoader: DataLoader
   constructor(props: Props) {
     super(props);
 
     this.state = {
       showChampion: false,
       content: props.content,
-      listData: ((props.content.list == null) ? [] : props.content.list),
+      listData: props.content.list ?? [],
       overlayData: null,
       urlHistoryState: window.history.state,
       showMoreVideos: false,
-      numberOfVideos: 100
-    }
+      numberOfVideos: 100,
+    };
     this.videoHandler = this.videoHandler.bind(this);
     this.navigate = this.navigate.bind(this);
     this.setData = this.setData.bind(this);
-    this.dataLoader = new DataLoader({ ...this.props, dataLoaded: (data: any) => { this.setData(data) } }, this.state)
   }
 
   videoHandler() {
     this.setState({
       showMoreVideos: true,
-    })
+    });
   }
 
-  componentDidMount() {
-    this.dataLoader.loadData()
+  async componentDidMount() {
+    const dataLoaded = (data: ListData[]) => this.setData(data);
+    let data: ListData[];
+    const query: DataQuery = this.props.content;
+    switch (query.class) {
+      case 'speakers':
+        await DataLoader.getSpeakers(query, dataLoaded);
+        return;
+      case 'staff':
+        data = await DataLoader.loadStaff(query);
+        break;
+      case 'overseers':
+        data = await DataLoader.loadOverseers();
+        break;
+      case 'events':
+        data = await DataLoader.loadEvents(query);
+        break;
+      case 'compassion':
+        data = await DataLoader.loadCompassion();
+        break;
+      case 'series':
+        await DataLoader.getSeriesByType(query, dataLoaded);
+        return;
+      case 'videos':
+      case 'curious':
+      case 'watch-page':
+        let id: string;
+        switch (query.selector) {
+          case 'sameSeries':
+            id = this.props.data?.series?.id;
+            data = await DataLoader.getSeriesVideos({
+              ...(query as SeriesQuery),
+              id,
+            });
+            break;
+          case 'highlights':
+            id = 'adult-sunday-shortcut-' + this.props?.data?.series?.id;
+            data = await DataLoader.getSeriesVideos({
+              ...(query as SeriesQuery),
+              id,
+            });
+            break;
+          case 'custom-playlist':
+            data = await DataLoader.getVideosCustomPlaylist(
+              query as CustomPlaylistQuery
+            );
+            break;
+          default:
+            await DataLoader.getVideos(query as VideoSeriesQuery, dataLoaded);
+            return;
+        }
+        break;
+      case 'blogs':
+        await DataLoader.getBlogs(query, dataLoaded);
+        return;
+      default:
+        console.error(`unknown list data type ${this.state.content.class}`);
+        return;
+    }
+    this.setData(data);
   }
+
   setData(data: any) {
     this.setState({
-      listData: this.state.listData.concat(data)
-    })
+      listData: this.state.listData.concat(data),
+    });
   }
   imgUrl(size: any) {
-
-    if (window.location.hostname === "localhost") {
-
-      return "https://localhost:3006"
-    }
-    else if (window.location.hostname.includes("beta"))
-      return "https://beta.themeetinghouse.com/cache/" + size
+    if (window.location.hostname === 'localhost') {
+      return 'https://localhost:3006';
+    } else if (window.location.hostname.includes('beta'))
+      return 'https://beta.themeetinghouse.com/cache/' + size;
     else
-      return "https://www.themeetinghouse.com/cache/" + size
+      return 'https://www.themeetinghouse.com/cache/' + size;
   }
   navigateUrlNewWindow(to: string) {
     window.open(
@@ -112,86 +199,99 @@ class ListItem extends React.Component<Props, State> {
     window.location.href = to;
   }
   navigate(to: string) {
-    this.props.history.push(to, "as")
+    this.props.history.push(to, 'as');
     const unblock = this.props.history.block('Are you sure you want to leave this page?');
     unblock();
 
   }
 
-  sortByDate(a: any, b: any, dir: "oldFirst" | "newFirst") {
-    const nameA = a.publishedDate.toUpperCase();
-    const nameB = b.publishedDate.toUpperCase();
+  sortByDate(a: BlogData, b: BlogData, dir: 'oldFirst' | 'newFirst') {
+    const nameA = (a?.publishedDate ?? '').toUpperCase();
+    const nameB = (b?.publishedDate ?? '').toUpperCase();
     if (nameA > nameB) {
-      return dir === "newFirst" ? -1 : 1;
+      return dir === 'newFirst' ? -1 : 1;
     }
     if (nameA < nameB) {
-      return dir === "newFirst" ? 1 : -1;
+      return dir === 'newFirst' ? 1 : -1;
     }
     return 0;
   }
 
   renderMoreVideosCard() {
     return (
-      <div onClick={() => this.setState({ numberOfVideos: this.state.numberOfVideos + 100 })} className={"ListItemVideo" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >
+      <div onClick={() => this.setState({ numberOfVideos: this.state.numberOfVideos + 100 })} className={'ListItemVideo' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')} >
         <div className="LoadMoreVideosCard">
           <div className="LoadMoreVideosText">Click to load more videos</div>
         </div>
-      </div>)
+      </div>);
   }
 
-  renderVideo(item: any) {
+  renderVideo(item: VideoData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
     return (
-      <div onClick={() => { this.handleClick(item) }} key={item.id} className={"ListItemVideo" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >
+      <div onClick={() => { this.handleClick(item); }} key={item.id ?? ''} className={'ListItemVideo' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')} >
         <div>
-          <img alt="TBD" className="ListItemVideoThumb" src={item.Youtube.snippet.thumbnails.high.url} />
+          <img alt="TBD" className="ListItemVideoThumb" src={(item as VideoByVideoTypeData)?.Youtube?.snippet?.thumbnails?.high?.url ?? ''} />
           <div className="ListItemPlayImageOverlay"><img alt="Play Icon" src="/static/svg/Play.svg"></img></div>
-          <div className="ListItemEpisodeNum" >{this.state.content.showEpisodeNumbers === false ? null : item.episodeNumber + ". "}{item.episodeTitle}</div>
-          <div className="ListItemSeriesTitle" >{item.seriesTitle != null ? item.seriesTitle : null}</div>
+          <div className="ListItemEpisodeNum" >{this.state.content.showEpisodeNumbers === false ? null : item.episodeNumber + '. '} {item.episodeTitle}</div>
+          <div className="ListItemSeriesTitle">{item.seriesTitle != null ? item.seriesTitle : null}</div>
           <div className="ListItemPublishedDate">{item.publishedDate}</div>
         </div>
 
-      </div>)
+      </div>);
   }
 
-  renderWatchPageVideo(item: any) {
+  renderWatchPageVideo(item: VideoData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
     return (
-      <div onClick={() => { this.handleClick(item) }} key={item.id} className={"WatchPageVideo" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >
+      <div onClick={() => { this.handleClick(item); }} key={item.id} className={'WatchPageVideo' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')} >
         <div>
-          <img alt="TBD" className="WatchPageThumb" src={item.Youtube.snippet.thumbnails.high.url} />
+          <img alt="TBD" className="WatchPageThumb" src={(item as VideoByVideoTypeData)?.Youtube?.snippet?.thumbnails?.high?.url ?? ''} />
           <div className="WatchPagePlayImageOverlay"><img alt="Play Icon" src="/static/svg/Play.svg"></img></div>
-          <div className="WatchPageEpisodeTitle">{item.episodeNumber && item.videoTypes !== "adult-sunday-shortcut" ? item.episodeNumber + ". " : null}{item.episodeTitle}</div>
+          <div className="WatchPageEpisodeTitle">{item.episodeNumber && item.videoTypes !== 'adult-sunday-shortcut' ? item.episodeNumber + '. ' : null}{item.episodeTitle}</div>
           <div className="WatchPagePublishedDate">{item.publishedDate}</div>
         </div>
 
-      </div>)
+      </div>);
   }
 
-  renderCurious(item: any) {
+  renderCurious(item: VideoData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
     return (
       <div className="CuriousWrapper">
-        <div onClick={() => this.handleClick(item)} key={item.id} className={"ListItemVideo" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >
+        <div onClick={() => this.handleClick(item)} key={item.id} className={'ListItemVideo' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')} >
           <div className="CuriousBox">
-            <div className="CuriousText">{this.state.content.showEpisodeNumbers === false ? null : item.episodeNumber + ". "}{item.episodeTitle}</div>
+            <div className="CuriousText">{this.state.content.showEpisodeNumbers === false ? null : item.episodeNumber + '. '}{item.episodeTitle}</div>
             <div className="WatchVideoTag">{this.state.content.hovertag}</div>
           </div>
         </div>
-      </div>)
+      </div>);
   }
 
-  renderBlogs(item: any) {
+  renderBlogs(item: BlogData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
     return (
-      <div className="BlogItem" key={item.id} onClick={() => this.navigateUrl("/posts/" + item.id)}>
-        <img alt={item.title + " series image"}
+      <div className="BlogItem" key={item.id} onClick={() => this.navigateUrl('/posts/' + item.id)}>
+        <img alt={item.blogTitle + ' series image'}
           className="BlogSquareImage"
-          src={"/static/photos/blogs/square/" + item.blogTitle.replace(/\?|[']/g, "") + ".jpg"}
-          onError={this.fallbackToImage("/static/NoCompassionLogo.png")} />
+          src={'/static/photos/blogs/square/' + (item.blogTitle ?? '').replace(/\?|[']/g, '') + '.jpg'}
+          onError={this.fallbackToImage('/static/NoCompassionLogo.png')}
+        />
         <div className="BlogContentContainer">
           <div className="BlogTitle">{item.blogTitle}<img className="blogarrow" alt="" src="/static/svg/ArrowRight black.svg" /></div>
-          <div className="BlogDetails">by <span className="author-only">{item.author}</span> on {item.publishedDate}</div>
+          <div className="BlogDetails">by <span className="author-only">{item.author}</span> on{' '}{item.publishedDate}</div>
           <div className="BlogDesc">{item.description}</div>
         </div>
       </div>
-    )
+    );
   }
 
   fallbackToImage(
@@ -205,33 +305,32 @@ class ListItem extends React.Component<Props, State> {
     };
   }
 
-  renderSpeaker(item: any) {
-
+  renderSpeaker(item: SpeakerData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
     return (
-      <div key={item.id} className="ListItemTeachingImageDiv" >
-        <img alt="TBD" className="ListItemTeachingImage" src="/static/images/teaching-3.png" onError={this.fallbackToImage("/static/Individual.png")} />
-        <div className="ListItemEpisodeLength" >{item.name}</div>
-        <div>{item.videos.items.length === 10 ? item.videos.items.length + "+" : item.videos.items.length} Episodes</div>
+      <div key={item.id} className="ListItemTeachingImageDiv">
+        <img alt="TBD" className="ListItemTeachingImage" src="/static/images/teaching-3.png" onError={this.fallbackToImage('/static/Individual.png')} />
+        <div className="ListItemEpisodeLength">{item.name}</div>
+        <div>{item?.videos?.items?.length === 10 ? item.videos.items.length + '+' : item?.videos?.items?.length} Episodes</div>
       </div>
-    )
-
+    );
   }
 
-
-  renderOverseer(item: any, index: any) {
-    const imgsrc: any = "/static/photos/overseers/" + item.FirstName + "_" + item.LastName + "_app.jpg"
+  renderOverseer(item: OverseerData, index: number): JSX.Element {
+    const imgsrc: any = '/static/photos/overseers/' + item.FirstName + '_' + item.LastName + '_app.jpg';
     return (
-      <div key={index} className="ListItemDiv3" >
-
-        <img alt={item.photoAlt} className="ListItemImage2"
-          onError={this.fallbackToImage("/static/Individual.png")}
+      <div key={index} className="ListItemDiv3">
+        <img alt={`${item.FirstName} ${item.LastName}`} className="ListItemImage2"
+          onError={this.fallbackToImage('/static/Individual.png')}
           src={this.imgUrl(640) + imgsrc}
-          srcSet={this.imgUrl(80) + imgsrc + " 80w," +
-            this.imgUrl(120) + imgsrc + " 120w," +
-            this.imgUrl(180) + imgsrc + " 180w," +
-            this.imgUrl(320) + imgsrc + " 320w," +
-            this.imgUrl(480) + imgsrc + " 480w," +
-            this.imgUrl(640) + imgsrc + " 640w"}
+          srcSet={this.imgUrl(80) + imgsrc + ' 80w,' +
+            this.imgUrl(120) + imgsrc + ' 120w,' +
+            this.imgUrl(180) + imgsrc + ' 180w,' +
+            this.imgUrl(320) + imgsrc + ' 320w,' +
+            this.imgUrl(480) + imgsrc + ' 480w,' +
+            this.imgUrl(640) + imgsrc + ' 640w'}
           sizes="(max-width: 320px) 80px,
                   (max-width: 480px) 120px,
                   (max-width: 640px) 180px,
@@ -245,38 +344,42 @@ class ListItem extends React.Component<Props, State> {
         <div className="ListItemPosition" >{item.Position}</div>
 
       </div>
-    )
+    );
   }
-  renderEvent(item: any) {
 
-    const start_date = new Date(item.start_time.substring(0, item.start_time.length - 2) + ":" + item.start_time.substring(item.start_time.length - 2))
+  renderEvent(item: EventData): JSX.Element | null {
+    if (!item) {
+      return null;
+    }
+
+    const start_date = new Date(item?.start_time?.substring(0, item.start_time.length - 2) + ':' + item?.start_time?.substring(item.start_time.length - 2));
     let durationStr = start_date.toLocaleTimeString(navigator.language, {
       hour: '2-digit',
-      minute: '2-digit'
+      minute: '2-digit',
     });
-    if (item.end_date != null) {
-      const end_date = new Date(item.end_date.substring(0, item.end_date.length - 2) + ":" + item.end_date.substring(item.end_date.length - 2))
-      durationStr = durationStr + "-" + end_date.toLocaleTimeString(navigator.language, {
+    if (item.end_time) {
+      const end_date = new Date(item.end_time.substring(0, item.end_time.length - 2) + ':' + item.end_time.substring(item.end_time.length - 2));
+      durationStr = durationStr + '-' + end_date.toLocaleTimeString(navigator.language, {
         hour: '2-digit',
-        minute: '2-digit'
+        minute: '2-digit',
       });
     }
-    let description
-    if (item.description.length > 300) {
-      if (item.description.indexOf(" ", 300) === -1)
-        description = item.description
+    let description;
+    if (item.description && item.description.length > 300) {
+      if (item.description.indexOf(' ', 300) === -1)
+        description = item.description;
       else
-        description = item.description.substring(0, item.description.indexOf(" ", 300)) + "..."
+        description = item.description.substring(0, item.description.indexOf(' ', 300)) + '...';
     }
     else
-      description = item.description
+      description = item.description;
     return (
-      <div key={item.id} onClick={() => { this.navigateUrlNewWindow("https://facebook.com/" + item.id) }} className="ListItemEvents" >
-        <div style={{ float: "left", marginLeft: "10px", marginRight: "40px" }}>
-          <div style={{ fontFamily: "Graphik Web", lineHeight: "3vw", fontSize: "2vw", fontWeight: "bold" }}>{start_date.toLocaleString('default', { month: 'long' })}</div>
-          <div style={{ fontFamily: "Graphik Web", lineHeight: "3vw", fontSize: "4vw", fontWeight: "bold" }}>{start_date.getDate()}</div>
+      <div key={item.id ?? ''} onClick={() => { this.navigateUrlNewWindow('https://facebook.com/' + item.id) }} className="ListItemEvents" >
+        <div style={{ float: 'left', marginLeft: '10px', marginRight: '40px' }}>
+          <div style={{ fontFamily: 'Graphik Web', lineHeight: '3vw', fontSize: '2vw', fontWeight: 'bold' }}>{start_date.toLocaleString('default', { month: 'long' })}</div>
+          <div style={{ fontFamily: 'Graphik Web', lineHeight: '3vw', fontSize: '4vw', fontWeight: 'bold' }}>{start_date.getDate()}</div>
         </div>
-        <div style={{ margin: "10px" }}>
+        <div style={{ margin: '10px' }}>
           <div className="ListItemEventsDescription" >{item.name}</div>
           <div className="ListItemEventsDescription2" >{description}</div>
           {item.place != null ? item.place.name != null ? <div className="ListItemEventsLocation" >{item.place.name}</div> : null : null}
@@ -284,41 +387,41 @@ class ListItem extends React.Component<Props, State> {
           {/*        <Button className="ListItemEventButton" onClick={() => this.navigate("calendar")}><img src="/static/Calendar.png" alt="Calendar Icon" />Add To Calendar</Button>
         <Button className="ListItemEventButton" onClick={() => this.navigate("share")}><img src="/static/Share.png" alt="Share Icon" />Share</Button>
     */}       </div>
-        <div style={{ clear: "left" }}></div>
+        <div style={{ clear: 'left' }}></div>
 
       </div>
-    )
+    );
 
   }
   easterEgg() {
-    this.setState({ showChampion: true })
+    this.setState({ showChampion: true });
   }
   renderStaff(item: any, index: any) {
-    const imgsrc = "/static/photos/" + (item.Staff == null ? "coordinators" : "staff") + "/" + (item.Staff == null ? item.sites[0] + "_" : "") + item.FirstName + "_" + item.LastName + "_app.jpg"
+    const imgsrc = '/static/photos/' + (item.Staff == null ? 'coordinators' : 'staff') + '/' + (item.Staff == null ? item.sites[0] + '_' : '') + item.FirstName + '_' + item.LastName + '_app.jpg';
     return (
       <div key={index} className="ListItemDiv3" >
-        {item.FirstName === "James" ? <div>
+        {item.FirstName === 'James' ? <div>
           <Konami action={() => { this.easterEgg() }}></Konami>
           {this.state.showChampion ?
-            (<div><Fireworks style={{ position: "fixed", width: "100%", height: "100%", left: 0, top: 0, zIndex: 20005 }} width={500} height={500} />
-              <img alt={item.photoAlt} className="ListItemImage2" style={{ position: "fixed", left: "30%", width: "30%", top: "10%", zIndex: 200004 }}
-                onError={this.fallbackToImage("/static/Individual.png")}
-                src={"/static/photos/" + (item.Staff == null ? "coordinators" : "staff") + "/" + (item.Staff == null ? item.sites[0] + "_" : "") + item.FirstName + "_" + item.LastName + "_app.jpg"} />
-              <h1 style={{ color: "#ffffff", fontSize: 100, position: "fixed", width: "80%", height: "20%", left: "10%", top: "70%", zIndex: 200006 }}>Young Adults Champion</h1></div>)
+            (<div><Fireworks style={{ position: 'fixed', width: '100%', height: '100%', left: 0, top: 0, zIndex: 20005 }} width={500} height={500} />
+              <img alt={item.photoAlt} className="ListItemImage2" style={{ position: 'fixed', left: '30%', width: '30%', top: '10%', zIndex: 200004 }}
+                onError={this.fallbackToImage('/static/Individual.png')}
+                src={'/static/photos/' + (item.Staff == null ? 'coordinators' : 'staff') + '/' + (item.Staff == null ? item.sites[0] + '_' : '') + item.FirstName + '_' + item.LastName + '_app.jpg'} />
+              <h1 style={{ color: '#ffffff', fontSize: 100, position: 'fixed', width: '80%', height: '20%', left: '10%', top: '70%', zIndex: 200006, }}>Young Adults Champion</h1></div>)
             : null}
         </div>
           : null
         }
 
         <img alt={item.photoAlt} className="ListItemImage2"
-          onError={this.fallbackToImage("/static/Individual.png")}
+          onError={this.fallbackToImage('/static/Individual.png')}
           src={this.imgUrl(640) + imgsrc}
-          srcSet={this.imgUrl(80) + imgsrc + " 80w," +
-            this.imgUrl(120) + imgsrc + " 120w," +
-            this.imgUrl(180) + imgsrc + " 180w," +
-            this.imgUrl(320) + imgsrc + " 320w," +
-            this.imgUrl(480) + imgsrc + " 480w," +
-            this.imgUrl(640) + imgsrc + " 640w"}
+          srcSet={this.imgUrl(80) + imgsrc + ' 80w,' +
+            this.imgUrl(120) + imgsrc + ' 120w,' +
+            this.imgUrl(180) + imgsrc + ' 180w,' +
+            this.imgUrl(320) + imgsrc + ' 320w,' +
+            this.imgUrl(480) + imgsrc + ' 480w,' +
+            this.imgUrl(640) + imgsrc + ' 640w'}
           sizes="(max-width: 320px) 80px,
                   (max-width: 480px) 120px,
                   (max-width: 640px) 180px,
@@ -329,105 +432,121 @@ class ListItem extends React.Component<Props, State> {
 
         <div className="ListItemName" >{item.FirstName} {item.LastName}</div>
         <div className="ListItemPosition" >{item.Position}</div>
-        {item.Email != null ? <div className="ListItemEmail"><a className="ListItemEmailText" href={"mailto:" + item.Email}>Email</a></div> : null}
+        {item.Email != null ? <div className="ListItemEmail"><a className="ListItemEmailText" href={'mailto:' + item.Email}>Email</a></div> : null}
         {item.Phone != null ? <div className="ListItemPhone">{item.Phone}</div> : null}
-        {item.facebook != null ? <a href={"https://www.facebook.com/" + item.facebook} className="ListItemA" ><img className="ListItemFB" src="/static/svg/Facebook.svg" alt="Facebook Logo" /></a> : null}
-        {item.instagram != null ? <a href={"https://twitter.com/" + item.instagram} className="ListItemA" ><img className="ListItemTwitter" src="/static/svg/Twitter.svg" alt="Twitter Logo" /></a> : null}
-        {item.twitter != null ? <a href={"https://www.instagram.com//" + item.twitter} className="ListItemA" ><img className="ListItemInstagram" src="/static/svg/Instagram.svg" alt="Instagram Logo" /></a> : null}
+        {item.facebook != null ? <a href={'https://www.facebook.com/' + item.facebook} className="ListItemA" ><img className="ListItemFB" src="/static/svg/Facebook.svg" alt="Facebook Logo" /></a> : null}
+        {item.instagram != null ? <a href={'https://twitter.com/' + item.instagram} className="ListItemA" ><img className="ListItemTwitter" src="/static/svg/Twitter.svg" alt="Twitter Logo" /></a> : null}
+        {item.twitter != null ? <a href={'https://www.instagram.com//' + item.twitter} className="ListItemA" ><img className="ListItemInstagram" src="/static/svg/Instagram.svg" alt="Instagram Logo" /></a> : null}
 
       </div>
-    )
+    );
   }
   renderCompassion(item: any) {
     return (
       <div key={item.id} className="ListItemCompassion" >
-        <img alt={item.imageAlt} className="ListItemCompassionLogo" src={item.image} onError={this.fallbackToImage("/static/NoCompassionLogo.png")} />
+        <img alt={item.imageAlt} className="ListItemCompassionLogo" src={item.image} onError={this.fallbackToImage('/static/NoCompassionLogo.png')} />
         <div className="ListItemEventsDescription" >{item.name}</div>
         <div className="ListItemEventsDescription2" >{item.description}</div>
         <div>{item.location}</div>
         {item.website != null ? (<div className="ListItemWebsiteContainer"><a className="ListItemWebsite" href={item.website}>Website</a></div>) : null}
-        {item.facebook != null ? (<a href={"https://www.facebook.com/" + item.facebook} className="ListItemA" ><img className="ListItemFB" src="/static/svg/Facebook.svg" alt="Facebook Logo" /></a>) : null}
-        {item.twitter != null ? (<a href={"https://twitter.com/" + item.twitter} className="ListItemA" ><img className="ListItemTwitter" src="/static/svg/Twitter.svg" alt="Twitter Logo" /></a>) : null}
-        {item.instagram != null ? (<a href={"https://www.instagram.com//" + item.instagram} className="ListItemA" ><img className="ListItemInstagram" src="/static/svg/Instagram.svg" alt="Instagram Logo" /></a>) : null}
+        {item.facebook != null ? (<a href={'https://www.facebook.com/' + item.facebook} className="ListItemA" ><img className="ListItemFB" src="/static/svg/Facebook.svg" alt="Facebook Logo" /></a>) : null}
+        {item.twitter != null ? (<a href={'https://twitter.com/' + item.twitter} className="ListItemA"><img className="ListItemTwitter" src="/static/svg/Twitter.svg" alt="Twitter Logo" /></a>) : null}
+        {item.instagram != null ? (<a href={'https://www.instagram.com//' + item.instagram} className="ListItemA" ><img className="ListItemInstagram" src="/static/svg/Instagram.svg" alt="Instagram Logo" /></a>) : null}
 
 
 
       </div>
-    )
+    );
   }
-  renderSeries(item: any) {
-    const seriesEnded = format(new Date(), "yyyy-MM-dd") > item.endDate
-    if (item.videos.items.length > 0) {
-      console.log(item.seriesType + "-" + item.title + ".jpg")
+  renderSeries(item: SeriesByTypeData) {
+    if (!item) {
+      return null;
+    }
+    const seriesEnded = item.endDate && format(new Date(), 'yyyy-MM-dd') > item.endDate;
+    const videos = item.videos?.items ?? [];
+    if (videos.length > 0) {
+      console.log(item.seriesType + '-' + item.title + '.jpg');
       return (
-        <div onClick={() => this.handleClick(item.videos.items.sort((a: any, b: any) => seriesEnded ? a.episodeNumber - b.episodeNumber : b.episodeNumber - a.episodeNumber)[0])} key={item.id} className="ListItemVideo" >
-          <img alt={item.title + " series image"}
+        <div onClick={() => this.handleClick(videos.sort((a, b) => {
+          const aNumber = a?.episodeNumber ?? 0;
+          const bNumber = b?.episodeNumber ?? 0;
+          return seriesEnded ? aNumber - bNumber : bNumber - aNumber;
+        })[0])}
+          key={item.id} className="ListItemVideo">
+          <img alt={item.title + ' series image'}
             className="ListItemImage2"
-            src={"/static/photos/series/" + item.seriesType + "-" + item.title.replace("?", "") + ".jpg"}
-            onError={this.fallbackToImage("/static/NoCompassionLogo.png")} />
+            src={'/static/photos/series/' + item.seriesType + '-' + (item.title ?? '').replace('?', '') + '.jpg'}
+            onError={this.fallbackToImage('/static/NoCompassionLogo.png')}
+          />
           <div className="ListItemName" >{item.title}</div>
-          <div className="ListYearEpisode">{this.showYears(item.startDate, item.endDate)}{item.videos.items.length} {item.videos.items.length === 1 ? "Episode" : "Episodes"}</div>
+          <div className="ListYearEpisode">{this.showYears(item.startDate, item.endDate)}{videos.length} {videos.length === 1 ? 'Episode' : 'Episodes'}</div>
         </div>
-      )
+      );
     }
     else {
-      console.log({ "None:": item })
-      return null
+      console.log({ 'None:': item });
+      return null;
     }
   }
-  renderItemRouter(item: any, index: any) {
-    if (this.state.content.class === "speakers")
-      return this.renderSpeaker(item)
-    else if (this.state.content.class === "videos")
-      return this.renderVideo(item)
-    else if (this.state.content.class === "staff")
-      return this.renderStaff(item, index)
-    else if (this.state.content.class === "overseers")
-      return this.renderOverseer(item, index)
-    else if (this.state.content.class === "events")
-      return this.renderEvent(item)
-    else if (this.state.content.class === "compassion")
-      return this.renderCompassion(item)
-    else if (this.state.content.class === "series")
-      return this.renderSeries(item)
-    else if (this.state.content.class === "curious")
-      return this.renderCurious(item)
-    else if (this.state.content.class === "watch-page")
-      return this.renderWatchPageVideo(item)
-    else if (this.state.content.class === "blogs")
-      return this.renderBlogs(item)
-    else return null
+  renderItemRouter(item: ListData, index: number) {
+    if (this.state.content.class === 'speakers')
+      return this.renderSpeaker(item as SpeakerData);
+    else if (this.state.content.class === 'videos')
+      return this.renderVideo(item as VideoData);
+    else if (this.state.content.class === 'staff')
+      return this.renderStaff(item as StaffData, index);
+    else if (this.state.content.class === 'overseers')
+      return this.renderOverseer(item as OverseerData, index);
+    else if (this.state.content.class === 'events')
+      return this.renderEvent(item as EventData);
+    else if (this.state.content.class === 'compassion')
+      return this.renderCompassion(item as CompassionData);
+    else if (this.state.content.class === 'series')
+      return this.renderSeries(item as SeriesByTypeData);
+    else if (this.state.content.class === 'curious')
+      return this.renderCurious(item as VideoData);
+    else if (this.state.content.class === 'watch-page')
+      return this.renderWatchPageVideo(item as VideoData);
+    else if (this.state.content.class === 'blogs')
+      return this.renderBlogs(item as BlogData);
+    else return null;
   }
 
   render() {
-    let data
-    (this.props.content.filterField == null) ? data = this.state.listData :
-      data = this.state.listData.filter((item: any) => {
-        return item[this.props.content.filterField].includes(this.props.content.filterValue)
-      })
+    const data: Array<ListData | string> =
+      this.props.content.filterField == null
+        ? this.state.listData
+        : this.state.listData.filter((item) => {
+          if (!item) {
+            return false;
+          }
+          return (item[
+            this.props.content.filterField as keyof ListData
+          ] as string).includes(this.props.content.filterValue);
+        });
 
-    const dataLength = data.length
+    const dataLength = data.length;
 
-    if (this.state.content.style === "horizontal") return (
+    if (this.state.content.style === 'horizontal') return (
       <div className="ListItem horizontal" >
         <div className="ListItemDiv1" >
-          <h1 className={"ListItemH1" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >{this.state.content.header1}</h1>
-          {this.state.content.text1 != null ? (<div className="ListItemText1" >{this.state.content.text1}</div>) : null}
+          <h1 className={'ListItemH1' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')} >{this.state.content.header1}</h1>
+          {this.state.content.text1 != null ? (<div className="ListItemText1">{this.state.content.text1}</div>) : null}
           <div className="ListItemDiv2" >
 
-            {this.state.content.class === "videos" ?
-              <HorizontalScrollList darkMode={this.props.pageConfig.logoColor === "white"}>
-                {data.slice(0, this.state.numberOfVideos).concat("card").map((item: any, index: any) => {
-                  if (item === "card")
-                    return dataLength > this.state.numberOfVideos ? this.renderMoreVideosCard() : null
+            {this.state.content.class === 'videos' ?
+              <HorizontalScrollList darkMode={this.props.pageConfig.logoColor === 'white'}>
+                {data.slice(0, this.state.numberOfVideos).concat('card').map((item, index) => {
+                  if (item === 'card')
+                    return dataLength > this.state.numberOfVideos ? this.renderMoreVideosCard() : null;
 
-                  return this.renderItemRouter(item, index)
+                  return this.renderItemRouter(item as ListData, index);
                 }
                 )}
               </HorizontalScrollList>
-              : <HorizontalScrollList darkMode={this.props.pageConfig.logoColor === "white"}>
+              : <HorizontalScrollList darkMode={this.props.pageConfig.logoColor === 'white'}>
                 {data.map((item: any, index: any) => {
-                  return this.renderItemRouter(item, index)
+                  return this.renderItemRouter(item, index);
                 }
                 )}
               </HorizontalScrollList>}
@@ -436,42 +555,43 @@ class ListItem extends React.Component<Props, State> {
         </div>
         <VideoOverlay onClose={() => { this.videoOverlayClose() }} data={this.state.overlayData}></VideoOverlay>
       </div>
-    )
-    else if (this.state.content.style === "blogs") {
-      data.sort((a: any, b: any) => this.sortByDate(a, b, "newFirst"))
+    );
+    else if (this.state.content.style === 'blogs') {
+      data.sort((a: any, b: any) => this.sortByDate(a, b, 'newFirst'));
 
-      const today = format(new Date(), "yyyy-MM-dd")
-      const dateChecked = data.filter((post: any) => post.publishedDate <= today && (post.expirationDate >= today || post.expirationDate))
+      const today = format(new Date(), 'yyyy-MM-dd');
+      const dateChecked = data.filter((post: any) => post.publishedDate <= today && (post.expirationDate >= today || post.expirationDate));
 
       return (
         <div className="ListItemDiv1 BlogItem" >
           <div className="BlogItemContainer">
             {dateChecked.map((item: any, index: any) => {
-              return this.renderItemRouter(item, index)
+              return this.renderItemRouter(item, index);
             }
             )}
           </div>
         </div>
-      )
+      );
     }
 
-    else if (this.state.content.style === "horizontal-video-player") {
+    else if (this.state.content.style === 'horizontal-video-player') {
       if (!data.length) {
-        return null
+        return null;
       }
+      const videoData = data as VideoData[];
       //videos are not stored in order within a series, so we sort here
-      if (data[0].videoTypes === "questions") 
-        data.sort((a: any, b: any) => a.episodeNumber - b.episodeNumber)
-      else 
-        data.sort((a: any, b: any) => this.sortByDate(a, b, "oldFirst"))
+      if (videoData[0]?.videoTypes === 'questions')
+        data.sort((a: any, b: any) => a.episodeNumber - b.episodeNumber);
+      else
+        data.sort((a: any, b: any) => this.sortByDate(a, b, 'oldFirst'));
       return (
-        <div className="ListItem horizontal-video-player" >
-          <div className="ListItemDiv1 horizontal-video-player" >
-            <h1 className={"ListItemH1 horizontal-video-player" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >{this.state.content.header1}</h1>
+        <div className="ListItem horizontal-video-player">
+          <div className="ListItemDiv1 horizontal-video-player">
+            <h1 className={'ListItemH1 horizontal-video-player' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')}>{this.state.content.header1}</h1>
             {this.state.content.text1 != null ? (<div className="ListItemText1" >{this.state.content.text1}</div>) : null}
             <div className="WatchPageContainer">
               {data.map((item: any, index: any) => {
-                return this.renderItemRouter(item, index)
+                return this.renderItemRouter(item, index);
               }
               )}
             </div>
@@ -479,20 +599,20 @@ class ListItem extends React.Component<Props, State> {
           </div>
           <VideoOverlay onClose={() => { this.videoOverlayClose() }} data={this.state.overlayData}></VideoOverlay>
         </div>
-      )
+      );
     }
 
-    else if (this.state.content.style === "curious-ui") {
-      data.sort(function (a: any, b: any) { return a.episodeNumber - b.episodeNumber })
+    else if (this.state.content.style === 'curious-ui') {
+      data.sort(function (a: any, b: any) { return a.episodeNumber - b.episodeNumber });
       return (
         <div className="ListItem horizontal" >
           <div className="ListItemDiv1" >
-            <h1 className={"ListItemH1" + (this.props.pageConfig.logoColor === "white" ? " whiteText" : "")} >{this.state.content.header1}</h1>
-            {this.state.content.text1 != null ? (<div className="CuriousText1" >{this.state.content.text1}</div>) : null}
+            <h1 className={'ListItemH1' + (this.props.pageConfig.logoColor === 'white' ? ' whiteText' : '')}>{this.state.content.header1}</h1>
+            {this.state.content.text1 != null ? (<div className="CuriousText1">{this.state.content.text1}</div>) : null}
             <div className="hide-mobile">
               <div className="CuriousContainer">
                 {data.slice(0, 6).map((item: any, index: any) => {
-                  return this.renderItemRouter(item, index)
+                  return this.renderItemRouter(item, index);
                 }
                 )}
               </div>
@@ -500,7 +620,7 @@ class ListItem extends React.Component<Props, State> {
 
             <div className="hide-desktop">
               {data.slice(0, 3).map((item: any, index: any) => {
-                return this.renderItemRouter(item, index)
+                return this.renderItemRouter(item, index);
               }
               )}
               {!this.state.showMoreVideos ? <button className="MoreVideos" onClick={this.videoHandler}>Load 3 More Questions</button> : null}
@@ -509,10 +629,10 @@ class ListItem extends React.Component<Props, State> {
           </div>
           <VideoOverlay onClose={() => { this.videoOverlayClose() }} data={this.state.overlayData}></VideoOverlay>
         </div>
-      )
+      );
     }
 
-    else if (this.state.content.style === "vertical") {
+    else if (this.state.content.style === 'vertical') {
       if (data.length > 0) {
         return (
           <div className="ListItem horizontal" >
@@ -522,26 +642,25 @@ class ListItem extends React.Component<Props, State> {
               <div className="ListItemSpeakersDiv" >
                 <HorizontalScrollList>
                   {data.map((item: any, index: any) => {
-                    return this.renderItemRouter(item, index)
+                    return this.renderItemRouter(item, index);
                   })}
                 </HorizontalScrollList>
               </div>
             </div>
           </div>
-        )
+        );
       } else {
-        return null
+        return null;
       }
     }
-    else if (this.state.content.style === "horizontalBig") return (
+    else if (this.state.content.style === 'horizontalBig') return (
       <div className="ListItem horizontalBig" >
         <div className="ListItemDiv1 ListItemAllSeries" >
           <h1 className="ListItemH1" >{this.state.content.header1}</h1>
           <div className="ListItemDiv6" >
             <HorizontalScrollList>
               {data.map((item: any, index: any) => {
-                return this.renderItemRouter(item, index)
-
+                return this.renderItemRouter(item, index);
               })}
             </HorizontalScrollList>
             <div className="ListItemDiv5" ></div>
@@ -552,7 +671,7 @@ class ListItem extends React.Component<Props, State> {
 
       </div>
     )
-    else if (this.state.content.style === "imageList") return (
+    else if (this.state.content.style === 'imageList') return (
       <div className="ListItem imageList" >
         <div className="ListItemDiv1" >
           <h1 className="ListItemH1ImageList" >{this.state.content.header1}</h1>
@@ -567,22 +686,22 @@ class ListItem extends React.Component<Props, State> {
                     <div
                       onClick={() => {
                         if (item.navigateTo)
-                          this.navigate(item.navigateTo)
+                          this.navigate(item.navigateTo);
                         else
                           if (item.url)
-                            this.navigateUrl(item.url)
+                            this.navigateUrl(item.url);
                       }}
-                      className={"imageList " + (item.url || item.navigateTo ? "hoverText" : "noHoverText")}>
+                      className={'imageList ' + (item.url || item.navigateTo ? 'hoverText' : 'noHoverText')}>
                       <h3 className="ListItemH3" ><img className="arrow" alt="" src="/static/svg/ArrowRight black.svg" />{item.title}</h3>
                       <div className="ListItemDiv11" >{item.text}</div>
                     </div>
                     <img className="ListItemH1ImageList2" src={this.imgUrl(480) + item.imageSrc} alt={item.imageAlt}
-                      srcSet={this.imgUrl(320) + item.imageSrc + " 320w," +
-                        this.imgUrl(480) + item.imageSrc + " 480w," +
-                        this.imgUrl(640) + item.imageSrc + " 640w," +
-                        this.imgUrl(1280) + item.imageSrc + " 1280w," +
-                        this.imgUrl(1920) + item.imageSrc + " 1920w," +
-                        this.imgUrl(2560) + item.imageSrc + " 2560w"}
+                      srcSet={this.imgUrl(320) + item.imageSrc + ' 320w,' +
+                        this.imgUrl(480) + item.imageSrc + ' 480w,' +
+                        this.imgUrl(640) + item.imageSrc + ' 640w,' +
+                        this.imgUrl(1280) + item.imageSrc + ' 1280w,' +
+                        this.imgUrl(1920) + item.imageSrc + ' 1920w,' +
+                        this.imgUrl(2560) + item.imageSrc + ' 2560w'}
                       sizes="(max-width: 320px) 320px,
                                (max-width: 480px) 480px,
                                (max-width: 640px) 640px,
@@ -591,16 +710,16 @@ class ListItem extends React.Component<Props, State> {
                                 2560px"
                     />
                   </div>
-                )
+                );
               })
             }
           </div>
         </div>
 
       </div>
-    )
-    return (null)
+    );
+    return null;
   }
 }
 
-export default withRouter(ListItem)
+export default withRouter(ListItem);

--- a/src/components/RenderRouter/WeatherItem.tsx
+++ b/src/components/RenderRouter/WeatherItem.tsx
@@ -3,16 +3,27 @@ import React from 'react';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
 import PropTypes from "prop-types";
 import "./WeatherItem.scss"
-import DataLoader from './DataLoader';
 import moment from 'moment';
 
+interface Content {
+    style: string
+
+    header1: string
+    header2: string
+    text1: string
+
+    list: Array<{
+        type: string
+        title: string
+    }>
+}
+
 interface Props extends RouteComponentProps {
-    content: any
+    content: Content
     data: any
 }
 interface State {
-    content: any,
-    locationData: any,
+    content: Content
     arrowOpacity: any
 }
 class HeroItem extends React.Component<Props, State> {
@@ -20,29 +31,16 @@ class HeroItem extends React.Component<Props, State> {
         router: PropTypes.object,
         history: PropTypes.object
     }
-    dataLoader: DataLoader
 
     constructor(props: Props, context: any) {
         super(props, context);
         this.state = {
             content: props.content,
-            locationData: [],
             arrowOpacity: 1
         }
         this.navigate = this.navigate.bind(this);
-        this.setData = this.setData.bind(this);
-        this.dataLoader = new DataLoader({ ...this.props, dataLoaded: (data: any) => { this.setData(data) } }, this.state)
+    }
 
-    }
-    componentDidMount() {
-
-        this.dataLoader.loadData()
-    }
-    setData(data: any) {
-        this.setState({
-            locationData: this.state.locationData.concat(data)
-        })
-    }
     getCalendarEventForLocation(locationItem: any) {
         let nextSunday = (moment().day() === 0 ? moment().add(1, "week") : moment().day(0)).startOf("day");
         let serviceHour = locationItem.serviceTimes[locationItem.serviceTimes.length - 1];

--- a/src/pages/admin/import-video.tsx
+++ b/src/pages/admin/import-video.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 import AdminMenu from '../../components/Menu/AdminMenu';
 //import * as customQueries from '../../graphql-custom/customQueries';
 
-//import * as queries from '../../graphql/queries';
-import * as customQueries from '../../graphql-custom/customQueries';
 import * as queries from '../../graphql/queries';
+import * as customQueries from '../../graphql-custom/customQueries';
 import * as mutations from '../../graphql/mutations';
 //{ API, graphqlOperation } 
 import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api/lib/types';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "target": "esnext",
+    "target": "es2019",
     "module": "esnext",
     "jsx": "preserve",
     "allowJs": true,


### PR DESCRIPTION
I plan to start adding types to components (replacing `any`). This requires establishing a schema for the list items and data queries. Step 1 is here, to break out the data queries to that different queries can accept different types, otherwise they would all be smooshed together and not be very helpful.

You'll also see that I removed some queries from `customQueries.ts`. These appear to be the same as the ones in `queries.ts`, if a little outdated. Currently we don't include `customQueries.ts` in `API.ts`, and we can't because of the conflicts, but this prevents us from using types for those queries.

This exercise found several inconsistencies between the actual data and DataLoader, so I fixed some bugs. For example, staff was using `lastName` instead of `LastName`, and comparing strings using `-`, which won't result in proper sorting, since a string minus a string is `NaN`.