### PR TITLE
Fix order of spiritually curious videos in player

### DIFF
--- a/src/components/RenderRouter/ListItem.tsx
+++ b/src/components/RenderRouter/ListItem.tsx
@@ -460,7 +460,10 @@ class ListItem extends React.Component<Props, State> {
         return null
       }
       //videos are not stored in order within a series, so we sort here
-      data.sort((a: any, b: any) => this.sortByDate(a, b, "oldFirst"))
+      if (data[0].videoTypes === "questions") 
+        data.sort((a: any, b: any) => a.episodeNumber - b.episodeNumber)
+      else 
+        data.sort((a: any, b: any) => this.sortByDate(a, b, "oldFirst"))
       return (
         <div className="ListItem horizontal-video-player" >
           <div className="ListItemDiv1 horizontal-video-player" >


### PR DESCRIPTION
Super specific bug, but [this change](https://github.com/themeetinghouse/web/pull/262/files#diff-4e914fa03d20987c572793981ebcc8acR118) in #262 broke the sort order for the spiritually curious videos within the video player.