### PR TITLE
Add limit, sortDirection to "Recent Blogs" on homepage

### DIFF
--- a/public/static/content/homepage.json
+++ b/public/static/content/homepage.json
@@ -161,6 +161,8 @@
                 "style": "twoImage",
                 "status": "Live",
                 "header1": "Recent Blog Entries",
+                "sortOrder": "DESC",
+                "limit": 2,
                 "button1Action": "/blogs"
             },
             {

--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -45,7 +45,7 @@ class BlogItem extends React.Component<Props, State> {
         }
         const getBlogByBlogStatus: any = API.graphql({
             query: queries.getBlogByBlogStatus,
-            variables: { blogStatus: this.state.content.status, sortDirection: this.state.content.sortOrder },
+            variables: { blogStatus: this.state.content.status, sortDirection: this.state.content.sortOrder, limit: this.state.content.limit },
             authMode: GRAPHQL_AUTH_MODE.API_KEY
         });
         getBlogByBlogStatus.then((json: any) => {


### PR DESCRIPTION
Adds sort on the query so that the most recent blogs are displayed (currently it is showing the first two blogs).

Adds limit since we only need to load two posts for the homepage.
