### PR TITLE
Fix path for favicon script

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
-<script type="text/javascript" src="handleIcons.js"></script>
+<script type="text/javascript" src="%PUBLIC_URL%/handleIcons.js"></script>
 
 <head>
   <meta charset="utf-8" />


### PR DESCRIPTION
The new dynamic favicon was broken on pages with path length >1...

Turns out it was looking for the script in `/path/handleIcons.js` instead of root.