### PR TITLE
Modify limit field on teaching scroll lists

### DIFF
--- a/public/static/content/spirituality.json
+++ b/public/static/content/spirituality.json
@@ -67,7 +67,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "bbq",
-                "limit": 50,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "showEpisodeNumbers": false,
                 "header1": "Popular Questions About Christianity",

--- a/public/static/content/teaching-curated.json
+++ b/public/static/content/teaching-curated.json
@@ -28,7 +28,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "bbq",
-                "limit": 50,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All BBQ Videos"
             },
@@ -53,7 +53,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "life-story",
-                "limit": 50,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Life Stories"
             },
@@ -62,7 +62,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "ky-youth",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Youth"
             }

--- a/public/static/content/teaching-kids-youth.json
+++ b/public/static/content/teaching-kids-youth.json
@@ -53,7 +53,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "ky-kids",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Kids"
             },
@@ -62,7 +62,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "ky-jrhigh",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Jr. High"
             },
@@ -71,7 +71,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "ky-youth",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Youth"
             },
@@ -80,7 +80,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "ky-srhigh",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Sr. High"
             },
@@ -89,6 +89,7 @@
                 "style": "horizontalBig",
                 "class": "series",
                 "subclass": "ky-kids",
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All Kids Series"
             },
@@ -97,6 +98,7 @@
                 "style": "horizontalBig",
                 "class": "series",
                 "subclass": "ky-jrhigh",
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All Jr. High Series"
             },
@@ -105,6 +107,7 @@
                 "style": "horizontalBig",
                 "class": "series",
                 "subclass": "ky-youth",
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All Youth Series"
             },
@@ -113,6 +116,7 @@
                 "style": "horizontalBig",
                 "class": "series",
                 "subclass": "ky-srhigh",
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All Sr. High Series"
             },

--- a/public/static/content/teaching.json
+++ b/public/static/content/teaching.json
@@ -40,7 +40,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "adult-sunday",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "All Teaching Videos"
             },
@@ -69,7 +69,7 @@
                 "style": "horizontal",
                 "class": "videos",
                 "subclass": "livestream-services",
-                "limit": 52,
+                "limit": 25,
                 "sortOrder": "DESC",
                 "header1": "Sunday Livestream"
             }


### PR DESCRIPTION
This was discussed at the weekly check-in. 50/52 videos -> 25 videos.

I also added a limit of 25 on the Kids & Youth series lists so users can access the grid view.