### PR TITLE
Patch scaled OG image url

### DIFF
--- a/src/components/RenderRouter/OgTags.tsx
+++ b/src/components/RenderRouter/OgTags.tsx
@@ -21,7 +21,7 @@ class Tags extends React.Component<Props, State> {
 
     ogImage() {
         try {
-            const imageUrl = tmhImageUrl(1920, this.state.content.image);
+            const imageUrl = tmhImageUrl(1920, this.state.content.image).split(' ')[0];
             return (
                 <Helmet>
                     <meta property="og:url" content={this.state.content.url} />


### PR DESCRIPTION
From the Facebook sharing debugger:

Provided og:image, https://www.themeetinghouse.com/cache/1920/static/images/og-images/homepage.jpg 1920w could not be downloaded. This can happen due to several different reasons such as your server using unsupported content-encoding. The crawler accepts deflate and gzip content encodings.