### PR TITLE
GitHub Actions redirect JSON generator patch

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -16,13 +16,10 @@ jobs:
         python-version: 3.8
     - name: Run a one-line script
       run: python ./.github/workflows/make_json.py
-    - name: switching from HTTPS to SSH
-      run: git remote set-url origin ${{ secrets.ssh }}
-    - name: check for changes
-      run: git status
-    - name: stage changed files
-      run: git add .
-    - name: commit changed files
-      run: git commit -m "Auto generate redirect JSON file(s)"
-    - name: push code to master
-      run: git push origin HEAD:master
+    - name: Commit json files
+      run: |
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'actions@github.com'
+        git add .
+        git commit -m 'auto-generate redirect JSON file(s)'
+        git push

--- a/public/static/redirect/learningteam.json
+++ b/public/static/redirect/learningteam.json
@@ -1,0 +1,32 @@
+{
+    "page": {
+        "name": "redirect",
+        "title": "The Meeting House",
+        "keywords": "",
+        "description":"",
+        "pageConfig": {
+            "movingMenu": false,
+            "showLogoText": true,
+            "logoColor":"black",
+            "showSearch":true,
+            "showFooter":true,
+            "showMenu":true
+        },
+        "content": [
+            {
+                "type": "hero",
+                "style": "full",
+                "image1": [
+                    {
+                        "src": "/static/images/about-us-1-2.jpg",
+                        "alt": "All of The Meeting House staff being silly outside of the Oakville site"
+                    }
+
+                ],
+                "header1": "Redirecting...",
+                "text1": "This will just take a second"
+            }
+
+        ]
+    }
+}

--- a/public/static/redirect/plantoprotectforelders.json
+++ b/public/static/redirect/plantoprotectforelders.json
@@ -1,0 +1,32 @@
+{
+    "page": {
+        "name": "redirect",
+        "title": "The Meeting House",
+        "keywords": "",
+        "description":"",
+        "pageConfig": {
+            "movingMenu": false,
+            "showLogoText": true,
+            "logoColor":"black",
+            "showSearch":true,
+            "showFooter":true,
+            "showMenu":true
+        },
+        "content": [
+            {
+                "type": "hero",
+                "style": "full",
+                "image1": [
+                    {
+                        "src": "/static/images/about-us-1-2.jpg",
+                        "alt": "All of The Meeting House staff being silly outside of the Oakville site"
+                    }
+
+                ],
+                "header1": "Redirecting...",
+                "text1": "This will just take a second"
+            }
+
+        ]
+    }
+}

--- a/public/static/redirect/pray.json
+++ b/public/static/redirect/pray.json
@@ -1,0 +1,32 @@
+{
+    "page": {
+        "name": "redirect",
+        "title": "The Meeting House",
+        "keywords": "",
+        "description":"",
+        "pageConfig": {
+            "movingMenu": false,
+            "showLogoText": true,
+            "logoColor":"black",
+            "showSearch":true,
+            "showFooter":true,
+            "showMenu":true
+        },
+        "content": [
+            {
+                "type": "hero",
+                "style": "full",
+                "image1": [
+                    {
+                        "src": "/static/images/about-us-1-2.jpg",
+                        "alt": "All of The Meeting House staff being silly outside of the Oakville site"
+                    }
+
+                ],
+                "header1": "Redirecting...",
+                "text1": "This will just take a second"
+            }
+
+        ]
+    }
+}


### PR DESCRIPTION
I tested this on my fork... it actually works now.

Also, adds the missing JSON files from the few times the action failed.