### PR TITLE
Padding on connect form for mobile browsers

### DIFF
--- a/src/components/RenderRouter/FormItem.scss
+++ b/src/components/RenderRouter/FormItem.scss
@@ -111,4 +111,8 @@
         width: 100vw;
         height: calc(100vh - 2*12.5vw - 25vw);
     }
+
+    .FormPadding {
+        padding-bottom: 15vh;
+    }
 }

--- a/src/components/RenderRouter/FormItem.tsx
+++ b/src/components/RenderRouter/FormItem.tsx
@@ -2,32 +2,27 @@
 import React from 'react';
 import "./FormItem.scss";
 import { FormItem } from '../types';
+import { isSafari, isChrome } from 'react-device-detect';
 
-interface Props {
+interface Params {
   content: FormItem
 }
 
-export default class ContentItem extends React.Component<Props>  {
-  constructor(props: Props) {
-    super(props);
-  }
-
-  render() {
-    return (
-      <div className="FormContainer">
-        <div className="FormItem">
-          {this.props.content.style === "white" ?
-            <h1 className="FormItemH1 black" >{this.props.content.header1}</h1> :
-            <h1 className="FormItemH1 white" >{this.props.content.header1}</h1>
-          }
-          {this.props.content.header2 ? <h2>{this.props.content.header2}</h2> : null}
-          {this.props.content.text1 ? <div className="FormItemText1">{this.props.content.text1}</div> : null}
-          <iframe
-            src={"https://meeting.formstack.com/forms/" + this.props.content.formId}
-            title="The Meeting House - Forms"
-            className="FormId" id="form-embed" scrolling="yes"></iframe>
-        </div>
+export default function ContentItem({ content }: Params) {
+  return (
+    <div className="FormContainer" >
+      <div className="FormItem">
+        {content.style === "white" ?
+          <h1 className="FormItemH1 black" >{content.header1}</h1> :
+          <h1 className="FormItemH1 white" >{content.header1}</h1>
+        }
+        {content.header2 ? <h2>{content.header2}</h2> : null}
+        {content.text1 ? <div className="FormItemText1">{content.text1}</div> : null}
+        <iframe
+          src={"https://meeting.formstack.com/forms/" + content.formId}
+          title="The Meeting House - Forms"
+          className={isSafari || isChrome ? "FormId FormPadding" : "FormId"} id="form-embed" scrolling="yes"></iframe>
       </div>
-    )
-  }
+    </div>
+  )
 }


### PR DESCRIPTION
As it turns out, some mobile browsers consider the bottom menu as part of the view height... This caused the submit button to be hidden on Chrome and Safari on mobile.

Tested on iOS with the following browsers: Chrome, Safari, Edge, Brave, Firefox, Opera - should be all good now.

Also, rewrote the component as a function instead of a class.