### PR TITLE
Patch errors reported by Sentry

### DIFF
--- a/src/components/RenderRouter/DataLoader.ts
+++ b/src/components/RenderRouter/DataLoader.ts
@@ -373,18 +373,17 @@ export default class DataLoader {
       }
     } catch (e) {
       console.error({ 'Error: ': e });
-      if (e.data) {
+      if (e.data?.getVideoByVideoType?.items) {
         dataLoaded(e.data.getVideoByVideoType.items.filter((item: VideoByVideoTypeData) => item?.viewCount ? parseInt(item?.viewCount, 10) >= query.minViews : false));
       }
-      if (e.data) {
-        if (e.data.getVideoByVideoType.nextToken) {
-          await this.getPopularVideos(
-            query,
-            dataLoaded,
-            e.data.getVideoByVideoType.nextToken
-          );
-        }
+      if (e.data?.getVideoByVideoType?.nextToken) {
+        await this.getPopularVideos(
+          query,
+          dataLoaded,
+          e.data.getVideoByVideoType.nextToken
+        );
       }
+
     }
   }
 

--- a/src/components/RenderRouter/VideoPlayer.tsx
+++ b/src/components/RenderRouter/VideoPlayer.tsx
@@ -20,14 +20,14 @@ import {
 import { Link } from 'components/Link/Link';
 
 interface Props {
-  content: any,
-  data: any
+  content: any;
+  data: any;
 }
 interface State {
-  data: any,
-  content: any,
-  videoPlayer: any
-  watchPageVideoElements: HTMLCollection
+  data: any;
+  content: any;
+  videoPlayer: any;
+  watchPageVideoElements: HTMLCollection;
 }
 
 export default class VideoPlayer extends React.Component<Props, State> {
@@ -39,7 +39,6 @@ export default class VideoPlayer extends React.Component<Props, State> {
       videoPlayer: null,
       watchPageVideoElements: document.getElementsByClassName('WatchPageVideo whiteText')
     }
-    console.log({ "VideoPlayer": props.data })
   }
 
   setVideoPlayer(event: { target: any }): void {
@@ -47,7 +46,7 @@ export default class VideoPlayer extends React.Component<Props, State> {
   }
 
   pauseVideo(): void {
-    if (this.state.videoPlayer.f)
+    if (this.state.videoPlayer?.f)
       this.state.videoPlayer.pauseVideo()
   }
 

--- a/src/components/ScaledImage/ScaledImage.tsx
+++ b/src/components/ScaledImage/ScaledImage.tsx
@@ -38,6 +38,12 @@ export default function ScaledImage(props: Props): ReactElement<Props> | null {
     return null;
   }
 
+  Object.entries = Object.entries || function entriesPolyFill(obj: Props['breakpointSizes']): [string, number][] {
+    return Object.keys(obj).map(key => {
+      return [key, obj[key]];
+    });
+  }
+
   const imageSizes = Object.entries(breakpoints);
   imageSizes.sort(([a], [b]) => Number(a) - Number(b))
 


### PR DESCRIPTION
Should fix THE-MEETING-HOUSE-JM, THE-MEETING-HOUSE-HH.

Polyfill for `Object.entries`. Closes #456 (THE-MEETING-HOUSE-M0).