### PR TITLE
display 404 page for handles not found

### DIFF
--- a/src/components/Archive/Archive.tsx
+++ b/src/components/Archive/Archive.tsx
@@ -28,7 +28,18 @@ export default class Archive extends React.Component<RouteComponentProps<Params>
 
         fetch(`/static/content/${pageType}.json`).then(function (response) {
             return response.json();
-        }).then((myJson) => this.setState({ content: myJson }))
+        }).then((myJson) => {
+            this.setState({ content: myJson })
+        }).catch((error: Error) => {
+            console.error(error)
+            fetch('/static/content/404.json').then(function (response) {
+                return response.json();
+            }).then((myJson) => {
+                this.setState({ content: myJson });
+            }).catch((e: Error) => {
+                console.error(e)
+            })
+        })
     }
 
     render() {

--- a/src/components/RenderRouter/ArchiveItem.tsx
+++ b/src/components/RenderRouter/ArchiveItem.tsx
@@ -48,10 +48,32 @@ class ArchiveItem extends React.Component<Props, State> {
         const query = { class: this.props.content.class, subclass: this.props.data, sortOrder: this.props.content.sortOrder };
         switch (query.class) {
             case 'series':
-                await DataLoader.getSeriesByType(query, dataLoaded, listenForNullToken);
+                async function loadSeriesByType() {
+                    await DataLoader.getSeriesByType(query, dataLoaded, listenForNullToken);
+                }
+                loadSeriesByType().then(() => {
+                    if (this.state.listData.length === 0) {
+                        //no data returned
+                        this.props.history.replace("/not-found")
+                    } else {
+                        console.log(this.state.listData)
+                    }
+                })
                 return;
             case 'videos':
-                await DataLoader.getVideos(query, dataLoaded, listenForNullToken);
+                async function loadVideos() {
+                    await DataLoader.getVideos(query, dataLoaded, listenForNullToken);
+                }
+                loadVideos().then(() => {
+                    if (this.state.listData.length === 0) {
+                        //no data returned
+                        this.props.history.replace("/not-found")
+                    } else {
+                        console.log(this.state.listData)
+                    }
+
+                })
+
                 return;
             default:
                 console.error(`unknown list data type ${this.props.content.class}`);

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -169,9 +169,17 @@ class HomePage extends React.Component<Props, State> {
       });
       getVideo.then((json: any) => {
         console.log({ "Success queries.getVideo: ": json });
-        this.setState({ data: json.data.getVideo })
+        if (json.data.getVideo === null) this.props.history.replace("/not-found")
+        else { this.setState({ data: json.data.getVideo }) }
+      }).catch((error: Error) => {
+        console.error(error)
+        Analytics.record({
+          name: 'error',
+          attributes: { page: jsonFile }
+        });
+        this.props.history.replace("/not-found")
+      })
 
-      }).catch((e: any) => { console.log(e) })
     } else if (pageType === 'blog') {
       const getBlog: any = API.graphql({
         query: queries.getBlog,
@@ -180,9 +188,17 @@ class HomePage extends React.Component<Props, State> {
       });
       getBlog.then((json: any) => {
         console.log({ "Success queries.getBlog: ": json });
-        this.setState({ data: json.data.getBlog })
+        if (json.data.getBlog === null) this.props.history.replace("/not-found")
+        else { this.setState({ data: json.data.getBlog }) }
         console.log(this.state.data);
-      }).catch((e: Error) => { console.error(e) })
+      }).catch((error: Error) => {
+        console.error(error)
+        Analytics.record({
+          name: 'error',
+          attributes: { page: jsonFile }
+        });
+        this.props.history.replace("/not-found")
+      })
     }
   }
 
@@ -191,7 +207,7 @@ class HomePage extends React.Component<Props, State> {
 
     return (
       <Switch>
-        <Route path={["/videos/:series/:episode", "/vidoes/:series"]}>
+        <Route path={["/videos/:series/:episode", "/videos/:series"]}>
           <VideoOverlay onClose={() => this.props.history.push("/")} data={this.state.data}></VideoOverlay>
         </Route>
         <Route path="/posts/:blog">


### PR DESCRIPTION
This is a potential stop-gap solution to the 404 page not being shown for handles not found. ( issue #441 )

for pageType of video, if the return of getVideo is an error, or null, the user will be sent to /not-found which loads 404
for pageType of blog, if the return of getBlog is an error or null, the user will be sent to /not-found which loads 404

I might be missing some event logging as I'm not sure which events require it.

Any thoughts or suggestions on whether this can be improved, or implemented in a better way?