### PR TITLE
Patch location selector

### DIFF
--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -66,7 +66,7 @@ class HeroItem extends React.Component<Props, State> {
   }
 
   locationChange(item: any) {
-    this.navigateTo(item.value)
+    this.props.history.push('/' + item.value)
   }
   navigate() {
     this.props.history.push("spirituality", "as")


### PR DESCRIPTION
Closes #379.

The Google search result mentioned in the issue no longer appears, but this fixes the underlying issue with the location selector, so the "pattern forever trapping you in a terrible vortex of being stuck on the locations page forever" is gone.