### PR TITLE
Further configuration for spell checker

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,19 @@
     ".vscode-insiders",
     "amplify",
     "src"
+  ],
+  "cSpell.language": "en,en-GB",
+  "cSpell.words": [
+    "Alliston",
+    "Ancaster",
+    "Bruxy",
+    "COVID-19",
+    "Cavey",
+    "Covid",
+    "Kidmax",
+    "livestream",
+    "livestreaming",
+    "Oakville",
+    "peacebuilding"
   ]
 }


### PR DESCRIPTION
- enable en-GB dictionary
- add TMH-specific language and word conventions to workspace dictionary