### PR TITLE
Convert twoImage blog module to multiImage

### DIFF
--- a/public/static/content/annualreport2020.json
+++ b/public/static/content/annualreport2020.json
@@ -4,7 +4,6 @@
     "title": "Annual Report 2020",
     "keywords": "",
     "description": "",
-
     "pageConfig": {
       "movingMenu": false,
       "showLogoText": true,
@@ -21,7 +20,6 @@
         "title": "Annual Report",
         "description": ""
       },
-
       {
         "type": "hero",
         "style": "full",
@@ -94,7 +92,6 @@
         "style": "oneImage",
         "header1": "Our impact is measured by His hands and feet.",
         "text1": "We have so much to be thankful for during our last fiscal year. Here are some of the things we’re celebrating:",
-
         "image1": [
           {
             "src": "/static/images/compassion-2-new.jpg",
@@ -145,7 +142,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Stories",
         "sortOrder": "DESC",
@@ -154,7 +151,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Stories",
         "sortOrder": "DESC",
@@ -163,7 +160,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Stories",
         "sortOrder": "DESC",

--- a/public/static/content/covid.json
+++ b/public/static/content/covid.json
@@ -40,7 +40,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Recent News and Updates",
         "sortOrder": "DESC",

--- a/public/static/content/gostorytelling.json
+++ b/public/static/content/gostorytelling.json
@@ -37,7 +37,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Stories",
         "sortOrder": "DESC",

--- a/public/static/content/homepage.json
+++ b/public/static/content/homepage.json
@@ -139,7 +139,7 @@
       },
       {
         "type": "blog",
-        "style": "twoImage",
+        "style": "multiImage",
         "status": "Live",
         "header1": "Recent Blog Entries",
         "sortOrder": "DESC",

--- a/src/components/RenderRouter/BlogItem.scss
+++ b/src/components/RenderRouter/BlogItem.scss
@@ -6,12 +6,6 @@
   }
 
   @media (min-width: 768px) {
-    .blogdescription {
-      padding-top: 2.2vw !important;
-      width: 31vw;
-      font-size: 1.1vw;
-    }
-
     .blogauthor {
       font-size: 0.83vw;
       width: 30.625vw;
@@ -109,8 +103,8 @@
 
     .BlogMultiImageItem {
       width: 38.33vw;
-      display: inline-block;
-      vertical-align: top;
+      display: inline-flex;
+      flex-direction: column;
       margin-right: 1.67vw;
       margin-bottom: 1.67vw;
     }
@@ -124,12 +118,10 @@
     }
 
     .blogdescription.multiImage {
-      padding-top: 1.67vw;
-      padding-bottom: 2.2vw;
+      margin: 2.2vw 0;
       width: 37.22vw;
       font-size: 1.1vw;
       color: #1a1a1a;
-      margin: 0;
     }
 
     .blogauthor.multiImage {
@@ -151,12 +143,6 @@
   }
 
   @media (min-width: 768px) and (max-width: 1024px) and (orientation: landscape) {
-    .blogdescription {
-      padding-top: 2.2vw !important;
-      width: 31vw;
-      font-size: 1.1vw;
-    }
-
     .blogauthor {
       font-size: 0.83vw;
       width: 30.625vw;
@@ -254,8 +240,8 @@
 
     .BlogMultiImageItem {
       width: 38.33vw;
-      display: inline-block;
-      vertical-align: top;
+      display: inline-flex;
+      flex-direction: column;
       margin-right: 1.67vw;
       margin-bottom: 1.67vw;
     }
@@ -269,12 +255,10 @@
     }
 
     .blogdescription.multiImage {
-      padding-top: 1.67vw;
-      padding-bottom: 2.2vw;
+      margin: 2.2vw 0;
       width: 37.22vw;
       font-size: 1.1vw;
       color: #1a1a1a;
-      margin: 0;
     }
 
     .blogauthor.multiImage {
@@ -368,12 +352,6 @@
       position: relative;
       left: 0vw;
       width: 100vw;
-    }
-
-    .blogdescription {
-      font-size: 4.3vw;
-      line-height: 6.4vw;
-      padding-bottom: 11.2vw;
     }
 
     .blog.multiImage {

--- a/src/components/RenderRouter/BlogItem.scss
+++ b/src/components/RenderRouter/BlogItem.scss
@@ -45,8 +45,6 @@
     }
 
     .author-underline {
-      //padding-bottom: 1px;
-      //border-bottom: solid 1px white;
       color: white;
     }
 
@@ -85,38 +83,39 @@
       padding-bottom: 5vh;
     }
 
-    .blog.twoImage {
+    .blog.multiImage {
       height: auto;
       padding-bottom: 5vw;
     }
 
-    .blog-h1.twoImage {
+    .blog-h1.multiImage {
       font-size: 1.6vw;
       top: 0;
       padding-bottom: 2.2vw;
       color: #1a1a1a;
     }
 
-    .BlogSquareImage.twoImage {
+    .BlogSquareImage.multiImage {
       display: none;
       display: hidden;
     }
 
-    .BlogBannerImage.twoImage {
+    .BlogBannerImage.multiImage {
       width: 38.33vw;
       height: 20.83vw;
       cursor: pointer;
       object-fit: cover;
     }
 
-    .BlogTwoImageItem {
+    .BlogMultiImageItem {
       width: 38.33vw;
       display: inline-block;
       vertical-align: top;
       margin-right: 1.67vw;
+      margin-bottom: 1.67vw;
     }
 
-    .blog-post-title.twoImage {
+    .blog-post-title.multiImage {
       padding: 0;
       font-size: 1.1vw;
       font-weight: bold;
@@ -124,7 +123,7 @@
       font-family: Graphik Web;
     }
 
-    .blogdescription.twoImage {
+    .blogdescription.multiImage {
       padding-top: 1.67vw;
       padding-bottom: 2.2vw;
       width: 37.22vw;
@@ -133,18 +132,21 @@
       margin: 0;
     }
 
-    .blogauthor.twoImage {
+    .blogauthor.multiImage {
       font-size: 0.83vw;
       color: #54565a;
     }
 
-    .author-underline.twoImage {
-      //border-bottom: solid 1px #1A1A1A;
+    .author-underline.multiImage {
       color: #1a1a1a;
     }
 
-    .BlogTwoImageTextContainer {
+    .BlogMultiImageTextContainer {
       padding-top: 2.2vw;
+    }
+
+    .multiImageButton {
+      margin-top: 1.67vw;
     }
   }
 
@@ -188,8 +190,6 @@
     }
 
     .author-underline {
-      //padding-bottom: 1px;
-      //border-bottom: solid 1px white;
       color: white;
     }
 
@@ -228,38 +228,39 @@
       padding-bottom: 5vh;
     }
 
-    .blog.twoImage {
+    .blog.multiImage {
       height: auto;
       padding-bottom: 5vw;
     }
 
-    .blog-h1.twoImage {
+    .blog-h1.multiImage {
       font-size: 1.6vw;
       top: 0;
       padding-bottom: 2.2vw;
       color: #1a1a1a;
     }
 
-    .BlogSquareImage.twoImage {
+    .BlogSquareImage.multiImage {
       display: none;
       display: hidden;
     }
 
-    .BlogBannerImage.twoImage {
+    .BlogBannerImage.multiImage {
       width: 38.33vw;
       height: 20.83vw;
       cursor: pointer;
       object-fit: cover;
     }
 
-    .BlogTwoImageItem {
+    .BlogMultiImageItem {
       width: 38.33vw;
       display: inline-block;
       vertical-align: top;
       margin-right: 1.67vw;
+      margin-bottom: 1.67vw;
     }
 
-    .blog-post-title.twoImage {
+    .blog-post-title.multiImage {
       padding: 0;
       font-size: 1.1vw;
       font-weight: bold;
@@ -267,7 +268,7 @@
       font-family: Graphik Web;
     }
 
-    .blogdescription.twoImage {
+    .blogdescription.multiImage {
       padding-top: 1.67vw;
       padding-bottom: 2.2vw;
       width: 37.22vw;
@@ -276,24 +277,24 @@
       margin: 0;
     }
 
-    .blogauthor.twoImage {
+    .blogauthor.multiImage {
       font-size: 0.83vw;
       color: #54565a;
     }
 
-    .author-underline.twoImage {
-      //border-bottom: solid 1px #1A1A1A;
+    .author-underline.multiImage {
       color: #1a1a1a;
     }
 
-    .BlogTwoImageTextContainer {
+    .BlogMultiImageTextContainer {
       padding-top: 2.2vw;
     }
 
-    .twoImageButton {
-      margin-top: 3.3vw;
+    .multiImageButton {
+      margin-top: 1.67vw;
     }
   }
+
   @media (max-width: 767px) {
     .blog-h1 {
       position: relative;
@@ -324,8 +325,6 @@
     }
 
     .author-underline {
-      //padding-bottom: 1px;
-      //border-bottom: solid 1px white;
       color: white;
     }
 
@@ -377,33 +376,33 @@
       padding-bottom: 11.2vw;
     }
 
-    .blog.twoImage {
+    .blog.multiImage {
       height: auto;
       padding: 10vw 5vw 0vw;
     }
 
-    .blog-h1.twoImage {
+    .blog-h1.multiImage {
       font-size: 6.4vw;
       top: 0;
       padding-bottom: 9.6vw;
       color: #1a1a1a;
     }
 
-    .BlogSquareImage.twoImage {
+    .BlogSquareImage.multiImage {
       width: 88.5vw;
       height: 88.5vw;
       object-fit: cover;
     }
 
-    .BlogBannerImage.twoImage {
+    .BlogBannerImage.multiImage {
       display: none;
     }
 
-    .BlogTwoImageItem {
+    .BlogMultiImageItem {
       margin-right: 1.67vw;
     }
 
-    .blog-post-title.twoImage {
+    .blog-post-title.multiImage {
       padding: 8.5vw 0 0;
       font-size: 4.26vw;
       line-height: 4.26vw;
@@ -412,7 +411,7 @@
       font-family: Graphik Web;
     }
 
-    .blogdescription.twoImage {
+    .blogdescription.multiImage {
       padding-top: 6.4vw;
       padding-bottom: 12.8vw;
       font-size: 4.26vw;
@@ -420,18 +419,17 @@
       color: #1a1a1a;
     }
 
-    .blogauthor.twoImage {
+    .blogauthor.multiImage {
       padding-top: 1.2vw;
       font-size: 3.2vw;
       color: #54565a;
     }
 
-    .author-underline.twoImage {
-      //border-bottom: solid 1px #1A1A1A;
+    .author-underline.multiImage {
       color: #1a1a1a;
     }
 
-    .BlogTwoImageTextContainer {
+    .BlogMultiImageTextContainer {
       margin-top: 2.2vw;
       padding-left: 2vw;
       padding-bottom: 12.8vw;

--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -166,10 +166,10 @@ class BlogItem extends React.Component<Props, State> {
   }
 
   render() {
-    if (this.state.publishedOnly === null) {
-      return null;
-    }
-    if (this.state.publishedOnly.length === 0) {
+    if (
+      this.state.publishedOnly === null ||
+      this.state.publishedOnly.length === 0
+    ) {
       return null;
     }
 
@@ -235,80 +235,84 @@ class BlogItem extends React.Component<Props, State> {
             </div>
           </div>
         );
-      case 'twoImage':
+      case 'multiImage':
         return (
           <div className="blog-item">
-            <div className="blog twoImage">
-              <h1 className="blog-h1 twoImage">{this.props.content.header1}</h1>
-              {this.state.publishedOnly.slice(0, 2).map((item, index) => {
-                const imageSquare = {
-                  src: this.getImageURI(item?.blogTitle, 'square'),
-                  alt: `blog post:" ${item?.id}`,
-                };
-                const imageBanner = {
-                  src: this.getImageURI(item?.blogTitle, 'banner'),
-                  alt: `blog post:" ${item?.id}`,
-                };
-                return (
-                  <div key={index} className="BlogTwoImageItem">
-                    <Link to={'/posts/' + item?.id}>
-                      {this.state.screenWidth > 768 ? (
-                        <ScaledImage
-                          image={imageBanner}
-                          className="BlogBannerImage twoImage"
-                          fallbackUrl="/static/photos/blogs/banner/fallback.jpg"
-                          breakpointSizes={{
-                            320: 160,
-                            480: 240,
-                            640: 320,
-                            1280: 640,
-                            1920: 960,
-                            2560: 1280,
-                          }}
-                        />
-                      ) : (
-                        <ScaledImage
-                          image={imageSquare}
-                          className="BlogSquareImage twoImage"
-                          fallbackUrl="/static/photos/blogs/square/fallback.jpg"
-                          breakpointSizes={{
-                            320: 320,
-                            480: 480,
-                            640: 640,
-                            1280: 1280,
-                            1920: 1920,
-                            2560: 2560,
-                          }}
-                        />
-                      )}
-                    </Link>
-                    <div className="BlogTwoImageTextContainer">
-                      <div className="blog-post-title twoImage">
-                        {item?.blogTitle}
-                      </div>
-                      <div className="blogauthor twoImage">
-                        by <span className="author-only">{item?.author}</span>{' '}
-                        on {item?.publishedDate}
-                      </div>
-                      <div className="blogdescription twoImage">
-                        {item?.description}
-                      </div>
-                      <Link
-                        className="blog-read-more"
-                        to={'/posts/' + item?.id}
-                      >
-                        Read More
+            <div className="blog multiImage">
+              <h1 className="blog-h1 multiImage">
+                {this.props.content.header1}
+              </h1>
+              {this.state.publishedOnly
+                .slice(0, this.props.content.limit ?? 2)
+                .map((item, index) => {
+                  const imageSquare = {
+                    src: this.getImageURI(item?.blogTitle, 'square'),
+                    alt: `blog post:" ${item?.id}`,
+                  };
+                  const imageBanner = {
+                    src: this.getImageURI(item?.blogTitle, 'banner'),
+                    alt: `blog post:" ${item?.id}`,
+                  };
+                  return (
+                    <div key={index} className="BlogMultiImageItem">
+                      <Link to={'/posts/' + item?.id}>
+                        {this.state.screenWidth > 768 ? (
+                          <ScaledImage
+                            image={imageBanner}
+                            className="BlogBannerImage multiImage"
+                            fallbackUrl="/static/photos/blogs/banner/fallback.jpg"
+                            breakpointSizes={{
+                              320: 160,
+                              480: 240,
+                              640: 320,
+                              1280: 640,
+                              1920: 960,
+                              2560: 1280,
+                            }}
+                          />
+                        ) : (
+                          <ScaledImage
+                            image={imageSquare}
+                            className="BlogSquareImage multiImage"
+                            fallbackUrl="/static/photos/blogs/square/fallback.jpg"
+                            breakpointSizes={{
+                              320: 320,
+                              480: 480,
+                              640: 640,
+                              1280: 1280,
+                              1920: 1920,
+                              2560: 2560,
+                            }}
+                          />
+                        )}
                       </Link>
+                      <div className="BlogMultiImageTextContainer">
+                        <div className="blog-post-title multiImage">
+                          {item?.blogTitle}
+                        </div>
+                        <div className="blogauthor multiImage">
+                          by <span className="author-only">{item?.author}</span>{' '}
+                          on {item?.publishedDate}
+                        </div>
+                        <div className="blogdescription multiImage">
+                          {item?.description}
+                        </div>
+                        <Link
+                          className="blog-read-more"
+                          to={'/posts/' + item?.id}
+                        >
+                          Read More
+                        </Link>
+                      </div>
                     </div>
-                  </div>
-                );
-              })}
-              {this.state.publishedOnly.length === 1 ? (
-                <div className="BlogTwoImageItem"></div>
+                  );
+                })}
+              {this.state.publishedOnly.length % 2 !== 0 ? (
+                <div className="BlogMultiImageItem"></div>
               ) : null}
               <LinkButton
                 size="lg"
-                className="inverted twoImageButton"
+                className="inverted multiImageButton"
                 to="/blog"
               >
                 View All Blogs

--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -166,10 +166,7 @@ class BlogItem extends React.Component<Props, State> {
   }
 
   render() {
-    if (
-      this.state.publishedOnly === null ||
-      this.state.publishedOnly.length === 0
-    ) {
+    if (this.state.publishedOnly?.length === 0 || !this.state.publishedOnly) {
       return null;
     }
 
@@ -243,7 +240,7 @@ class BlogItem extends React.Component<Props, State> {
                 {this.props.content.header1}
               </h1>
               {this.state.publishedOnly
-                .slice(0, this.props.content.limit ?? 2)
+                .slice(0, this.props.content.limit)
                 .map((item, index) => {
                   const imageSquare = {
                     src: this.getImageURI(item?.blogTitle, 'square'),
@@ -256,7 +253,7 @@ class BlogItem extends React.Component<Props, State> {
                   return (
                     <div key={index} className="BlogMultiImageItem">
                       <Link to={'/posts/' + item?.id}>
-                        {this.state.screenWidth > 768 ? (
+                        {this.state.screenWidth >= 768 ? (
                           <ScaledImage
                             image={imageBanner}
                             className="BlogBannerImage multiImage"
@@ -307,16 +304,19 @@ class BlogItem extends React.Component<Props, State> {
                     </div>
                   );
                 })}
-              {this.state.publishedOnly.length % 2 !== 0 ? (
+              {this.state.publishedOnly.length % 2 !== 0 &&
+              this.state.screenWidth >= 768 ? (
                 <div className="BlogMultiImageItem"></div>
               ) : null}
-              <LinkButton
-                size="lg"
-                className="inverted multiImageButton"
-                to="/blog"
-              >
-                View All Blogs
-              </LinkButton>
+              {!this.props.content.hideAllBlogsButton ? (
+                <LinkButton
+                  size="lg"
+                  className="inverted multiImageButton"
+                  to="/blog"
+                >
+                  View All Blogs
+                </LinkButton>
+              ) : null}
             </div>
           </div>
         );

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -50,4 +50,5 @@ export interface BlogItemContent {
   sortOrder?: 'DESC' | 'ASC';
   limit?: number;
   blogSeries?: string;
+  hideAllBlogsButton?: boolean;
 }

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -44,7 +44,7 @@ export interface FormItem {
 
 export interface BlogItemContent {
   type: 'blog';
-  style: 'twoImage' | 'hero';
+  style: 'multiImage' | 'hero';
   status: 'Live';
   header1?: string;
   sortOrder?: 'DESC' | 'ASC';


### PR DESCRIPTION
Per request in #236.

@lucastbelem @deeinstereo here are the changes:

* I renamed the module for clarity, so its now `"style": "multiImage"`
* You can set any number for `"limit"` now or just leave it out if you want the entire series
* I thought it might be useful to hide the "View All Blogs" button - if you want to do this add `"hideAllBlogsButton": true`

Example 1: limit = 5, hide "View All Blogs"

```
{
"type": "blog",
"style": "multiImage",
"status": "Live",
"header1": "Five Blogs Only and The Button is Hidden",
"sortOrder": "DESC",
"limit": 5,
"blogSeries": "Some Series",
"hideAllBlogsButton: true
}
```

Example 2: no limit (will show the entire blog series)

```
{
"type": "blog",
"style": "multiImage",
"status": "Live",
"header1": "This Shows The Entire Series",
"sortOrder": "DESC",
"blogSeries": "Some Other Series",
}
```

