### PR TITLE
Blogs: fix sort order, allow admins to hide posts from main blog index

### DIFF
--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -5,7 +5,12 @@ import { API } from 'aws-amplify';
 import moment from 'moment';
 import { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api/lib/types';
 import { Link, LinkButton } from 'components/Link/Link';
-import { GetBlogSeriesQuery, GetBlogByBlogStatusQuery } from 'API';
+import {
+  GetBlogSeriesQuery,
+  GetBlogByBlogStatusQuery,
+  GetBlogByBlogStatusQueryVariables,
+  ModelSortDirection,
+} from 'API';
 import { BlogItemContent } from '../types';
 import ScaledImage from '../ScaledImage/ScaledImage';
 
@@ -60,14 +65,17 @@ class BlogItem extends React.Component<Props, State> {
     try {
       const today = moment();
       const todayString = today.format('YYYY-MM-DD');
+      const queryVariables: GetBlogByBlogStatusQueryVariables = {
+        publishedDate: { le: todayString },
+        blogStatus: this.props.content.status,
+        sortDirection:
+          ModelSortDirection[this.props.content.sortOrder ?? 'DESC'],
+        limit: this.props.content.limit,
+        filter: { hiddenMainIndex: { ne: true } },
+      };
       const json = (await API.graphql({
         query: customQueries.getBlogByBlogStatus,
-        variables: {
-          publishedDate: { le: todayString },
-          blogStatus: this.props.content.status,
-          sortDirection: this.props.content.sortOrder,
-          limit: this.props.content.limit,
-        },
+        variables: queryVariables,
         authMode: GRAPHQL_AUTH_MODE.API_KEY,
       })) as GraphQLResult<GetBlogByBlogStatusQuery>;
 
@@ -128,7 +136,7 @@ class BlogItem extends React.Component<Props, State> {
                 moment(item?.blogPost?.expirationDate, 'YYYY-MM-DD').isAfter(
                   today
                 )) &&
-              item?.blogPost.blogStatus === 'Live'
+              item?.blogPost.blogStatus === this.props.content.status
             ) {
               publishedOnly.push(item?.blogPost);
             }

--- a/src/components/RenderRouter/DataLoader.ts
+++ b/src/components/RenderRouter/DataLoader.ts
@@ -83,8 +83,8 @@ export interface SpeakerQuery extends DataLoaderQuery {
 
 export interface BlogQuery extends DataLoaderQuery {
   class: 'blogs';
-
   status: string;
+  sortOrder: ModelSortDirection;
 }
 
 export interface SeriesByTypeQuery extends DataLoaderQuery {
@@ -495,6 +495,7 @@ export default class DataLoader {
     const vars: GetBlogByBlogStatusQueryVariables = {
       nextToken: nextToken,
       blogStatus: query.status,
+      sortDirection: query.sortOrder,
       limit: 200,
     };
     const getBlogByBlogStatus = API.graphql(

--- a/src/components/RenderRouter/DataLoader.ts
+++ b/src/components/RenderRouter/DataLoader.ts
@@ -497,6 +497,7 @@ export default class DataLoader {
       blogStatus: query.status,
       sortDirection: query.sortOrder,
       limit: 200,
+      filter: { hiddenMainIndex: { ne: true } },
     };
     const getBlogByBlogStatus = API.graphql(
       graphqlOperation(customQueries.getBlogByBlogStatus, vars)

--- a/src/components/RenderRouter/ListItem.tsx
+++ b/src/components/RenderRouter/ListItem.tsx
@@ -34,6 +34,7 @@ import ScaledImage, {
 } from 'components/ScaledImage/ScaledImage';
 import { Link } from 'components/Link/Link';
 import { RouteParams } from '../../pages/HomePage';
+import moment from 'moment';
 
 interface Props extends RouteComponentProps<RouteParams> {
   content: any;
@@ -1282,11 +1283,11 @@ class ListItem extends React.Component<Props, State> {
 
       data.sort((a: any, b: any) => this.sortByDate(a, b, 'newFirst'));
 
-      const today = format(new Date(), 'yyyy-MM-dd');
+      const today = moment();
       const dateChecked = data.filter(
         (post: any) =>
-          post.publishedDate <= today &&
-          (post.expirationDate >= today || post.expirationDate)
+          post?.expirationDate === 'none' ||
+          moment(post?.expirationDate, 'YYYY-MM-DD').isAfter(today)
       );
 
       return (

--- a/src/pages/admin/create-blog.tsx
+++ b/src/pages/admin/create-blog.tsx
@@ -411,7 +411,16 @@ class Index extends React.Component<EmptyProps, State> {
         editorState: EditorState.createWithContent(contentState),
       });
 
-      this.setState({ blogObject: this.state.blogToEditObject });
+      const temp: any = this.state.blogToEditObject;
+      delete temp.__typename;
+      delete temp.blogSeries;
+      delete temp.createdAt;
+      delete temp.createdBy;
+      delete temp.createdBy;
+      delete temp.updatedAt;
+      delete temp.series;
+
+      this.setState({ blogObject: temp });
 
       if (
         this.state.blogToEditObject.expirationDate !== 'none' &&
@@ -466,7 +475,6 @@ class Index extends React.Component<EmptyProps, State> {
   async handleNewBlogSeries() {
     this.setState({ newBlogSeriesModal: false });
     if (this.state.newBlogSeries.title) {
-      this.updateSeriesField('id', this.state.newBlogSeries.title);
       try {
         const saveBlogSeries = (await API.graphql({
           query: mutations.createBlogSeries,
@@ -487,10 +495,10 @@ class Index extends React.Component<EmptyProps, State> {
     }
   }
 
-  updateSeriesField(field: keyof CreateBlogSeriesInput, value: string) {
-    this.setState((prevState) => ({
-      newBlogSeries: { ...prevState.newBlogSeries, [field]: value },
-    }));
+  updateBlogSeries(value: string) {
+    this.setState({
+      newBlogSeries: { title: value, id: value },
+    });
   }
 
   updateBlogField(
@@ -629,7 +637,7 @@ class Index extends React.Component<EmptyProps, State> {
           <input
             value={this.state.newBlogSeries.title ?? ''}
             onChange={(item) => {
-              this.updateSeriesField('title', item.target.value);
+              this.updateBlogSeries(item.target.value);
             }}
           />
         </label>

--- a/src/pages/admin/create-blog.tsx
+++ b/src/pages/admin/create-blog.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { EditorState, ContentState, convertToRaw } from 'draft-js';
 import { Editor } from 'react-draft-wysiwyg';
-import Amplify from 'aws-amplify';
 import AdminMenu from '../../components/Menu/AdminMenu';
 import BlogPreview from './BlogPreview';
 import { AmplifyAuthenticator } from '@aws-amplify/ui-react';
@@ -9,9 +8,8 @@ import awsmobile from '../../aws-exports';
 import * as customQueries from '../../graphql-custom/customQueries';
 import * as queries from '../../graphql/queries';
 import * as mutations from '../../graphql/mutations';
-import { GRAPHQL_AUTH_MODE } from '@aws-amplify/api/lib/types';
-import { API } from 'aws-amplify';
-import { Storage } from 'aws-amplify';
+import { GRAPHQL_AUTH_MODE, GraphQLResult } from '@aws-amplify/api/lib/types';
+import Amplify, { API, Storage } from 'aws-amplify';
 import { Modal } from 'reactstrap';
 import { v1 as uuidv1 } from 'uuid';
 import draftToHtml from 'draftjs-to-html';
@@ -22,6 +20,21 @@ import 'react-datepicker/dist/react-datepicker.css';
 import format from 'date-fns/format';
 import parse from 'date-fns/parse';
 import './create-blog.scss';
+import {
+  BlogBridgeByPostQuery,
+  CreateBlogInput,
+  CreateBlogMutation,
+  CreateBlogSeriesBridgeMutation,
+  CreateBlogSeriesInput,
+  CreateBlogSeriesMutation,
+  DeleteBlogMutation,
+  DeleteBlogSeriesBridgeMutation,
+  DeleteBlogSeriesMutation,
+  ListBlogSeriessQuery,
+  ListBlogsQuery,
+  ListSeriessQuery,
+  UpdateBlogMutation,
+} from '../../API';
 
 Amplify.configure(awsmobile);
 const federated = {
@@ -29,36 +42,40 @@ const federated = {
 };
 
 interface State {
-  editorState: any;
-  title: string;
-  author: string;
-  desc: string;
-  showPreview: boolean;
-  videoSeriesList: any;
-  blogSeriesList: any;
-  selectedVideoSeries: any;
-  selectedBlogSeries: any;
-  deselectedBlogSeries: any;
-  blogBridgeList: any;
-  selectedTags: any;
-  editMode: boolean;
-  blogObject: any;
-  newBlogSeries: any;
+  blogObject: CreateBlogInput;
+  blogToEditObject: NonNullable<
+    NonNullable<ListBlogsQuery['listBlogs']>['items']
+  >[0];
+  editorState: EditorState;
+  disableCalendar: boolean;
+  publishDate: Date;
+  expireDate: Date;
+
+  videoSeriesList: NonNullable<
+    NonNullable<ListSeriessQuery['listSeriess']>['items']
+  >;
+  blogPostsList: NonNullable<NonNullable<ListBlogsQuery['listBlogs']>['items']>;
+  blogSeriesList: NonNullable<
+    NonNullable<ListBlogSeriessQuery['listBlogSeriess']>['items']
+  >;
+  selectedBlogSeries: string[];
+  deselectedBlogSeries: string[];
+  blogBridgeList: NonNullable<
+    BlogBridgeByPostQuery['blogBridgeByPost']
+  >['items'];
+  newBlogSeries: CreateBlogSeriesInput;
+
   currentTag: string;
-  moreOptions: boolean;
-  currentVideoSeries: any;
-  currentBlogSeries: any;
+  currentBlogSeries: string;
+  blogToEditId: string;
+  showAlert: string;
+
+  showPreview: boolean;
+  editMode: boolean;
   showEditModal: boolean;
   newBlogSeriesModal: boolean;
-  blogToEditID: any;
-  blogToEditObject: any;
-  blogPostsList: any;
-  publishDate: any;
-  expireDate: any;
-  videoSeries: any;
-  showAlert: any;
-  disableCalendar: boolean;
-  blogStatus: string;
+  moreOptions: boolean;
+
   delete: string;
   understand: string;
   deleteBlogSeries: string;
@@ -67,81 +84,79 @@ interface State {
 
 class Index extends React.Component<EmptyProps, State> {
   deleteConfirmation = 'Delete forever';
+  nullString = 'NullValueString';
   constructor(props: EmptyProps) {
     super(props);
     this.state = {
-      // text input
+      blogObject: {
+        id: '',
+        author: '',
+        blogTitle: '',
+        expirationDate: 'none',
+        publishedDate: format(new Date(), 'yyyy-MM-dd'),
+        description: '',
+        blogStatus: 'Unlisted',
+        content: '',
+        hiddenMainIndex: false,
+        tags: [],
+        blogSeriesId: this.nullString,
+      },
+      blogToEditObject: null,
       editorState: EditorState.createEmpty(),
-      title: '',
-      author: '',
-      desc: '',
-
-      // tags, series, status and date input
-      currentTag: '',
-      blogStatus: 'Unlisted',
-      currentVideoSeries: null,
-      currentBlogSeries: null,
-      selectedVideoSeries: null,
-      selectedBlogSeries: [],
-      deselectedBlogSeries: [],
-      selectedTags: [],
+      disableCalendar: true,
       publishDate: new Date(),
       expireDate: new Date(),
-      disableCalendar: true,
 
-      // queried and loaded data
       videoSeriesList: [],
-      blogSeriesList: [],
       blogPostsList: [],
-      videoSeries: null,
-      blogBridgeList: null,
+      blogSeriesList: [],
+      selectedBlogSeries: [],
+      deselectedBlogSeries: [],
+      blogBridgeList: [],
+      newBlogSeries: {
+        id: '',
+        title: '',
+      },
 
-      // display states
-      showPreview: false,
-      moreOptions: false,
-      showEditModal: false,
-      newBlogSeriesModal: false,
+      currentTag: '',
+      currentBlogSeries: '',
+      blogToEditId: '',
       showAlert: '',
 
-      // determines which existing blog the user wishes to edit
-      blogToEditID: null,
-      blogToEditObject: null,
-
+      showPreview: false,
       editMode: false,
+      showEditModal: false,
+      newBlogSeriesModal: false,
+      moreOptions: false,
 
-      // mutation inputs
-      blogObject: {},
-      newBlogSeries: {},
-
-      // the power to delete things
       delete: '',
       understand: '',
       deleteBlogSeries: '',
       understandBlogSeries: '',
     };
 
-    this.listSeries(null);
-    this.listBlogs(null);
-    this.listBlogSeries(null);
+    this.listSeries();
+    this.listBlogs();
+    this.listBlogSeries();
   }
 
   // QUERY FUNCTIONS
 
-  async listSeries(nextToken: any) {
+  async listSeries(nextToken?: string) {
     try {
-      const listSeries: any = await API.graphql({
+      const listSeries = (await API.graphql({
         query: customQueries.listSeriess,
         variables: { nextToken: nextToken, sortDirection: 'DESC', limit: 200 },
         authMode: GRAPHQL_AUTH_MODE.API_KEY,
-      });
+      })) as GraphQLResult<ListSeriessQuery>;
 
       console.log({ 'Success customQueries.listSeries: ': listSeries });
       this.setState({
         videoSeriesList: this.state.videoSeriesList
-          .concat(listSeries.data.listSeriess.items)
-          .sort(function (a: any, b: any) {
-            const nameA = a.id.toUpperCase();
-            const nameB = b.id.toUpperCase();
+          .concat(listSeries?.data?.listSeriess?.items ?? [])
+          .sort((a, b) => {
+            const nameA = a?.id?.toUpperCase() ?? '';
+            const nameB = b?.id?.toUpperCase() ?? '';
             if (nameA < nameB) {
               return -1;
             }
@@ -151,28 +166,28 @@ class Index extends React.Component<EmptyProps, State> {
             return 0;
           }),
       });
-      if (listSeries.data.listSeriess.nextToken != null)
+      if (listSeries?.data?.listSeriess?.nextToken)
         this.listSeries(listSeries.data.listSeriess.nextToken);
     } catch (e) {
       console.error(e);
     }
   }
 
-  async listBlogs(nextToken: any) {
+  async listBlogs(nextToken?: string) {
     try {
-      const listBlogs: any = await API.graphql({
+      const listBlogs = (await API.graphql({
         query: queries.listBlogs,
         variables: { nextToken: nextToken, sortDirection: 'DESC', limit: 200 },
         authMode: GRAPHQL_AUTH_MODE.API_KEY,
-      });
+      })) as GraphQLResult<ListBlogsQuery>;
 
       console.log({ 'Success queries.listBlogs: ': listBlogs });
       this.setState({
         blogPostsList: this.state.blogPostsList
-          .concat(listBlogs.data.listBlogs.items)
-          .sort(function (a: any, b: any) {
-            const nameA = a.id.toUpperCase();
-            const nameB = b.id.toUpperCase();
+          .concat(listBlogs?.data?.listBlogs?.items ?? [])
+          .sort((a, b) => {
+            const nameA = a?.id?.toUpperCase() ?? '';
+            const nameB = b?.id?.toUpperCase() ?? '';
             if (nameA < nameB) {
               return -1;
             }
@@ -182,28 +197,28 @@ class Index extends React.Component<EmptyProps, State> {
             return 0;
           }),
       });
-      if (listBlogs.data.listBlogs.nextToken != null)
+      if (listBlogs?.data?.listBlogs?.nextToken)
         this.listBlogs(listBlogs.data.listBlogs.nextToken);
     } catch (e) {
       console.error(e);
     }
   }
 
-  async listBlogSeries(nextToken: any) {
+  async listBlogSeries(nextToken?: string) {
     try {
-      const listBlogSeries: any = await API.graphql({
+      const listBlogSeries = (await API.graphql({
         query: queries.listBlogSeriess,
         variables: { nextToken: nextToken, sortDirection: 'DESC', limit: 200 },
         authMode: GRAPHQL_AUTH_MODE.API_KEY,
-      });
+      })) as GraphQLResult<ListBlogSeriessQuery>;
 
       console.log({ 'Success queries.listBlogSeries: ': listBlogSeries });
       this.setState({
         blogSeriesList: this.state.blogSeriesList
-          .concat(listBlogSeries.data.listBlogSeriess.items)
-          .sort(function (a: any, b: any) {
-            const nameA = a.title.toUpperCase();
-            const nameB = b.title.toUpperCase();
+          .concat(listBlogSeries?.data?.listBlogSeriess?.items ?? [])
+          .sort((a, b) => {
+            const nameA = a?.title?.toUpperCase() ?? '';
+            const nameB = b?.title?.toUpperCase() ?? '';
             if (nameA < nameB) {
               return -1;
             }
@@ -213,7 +228,7 @@ class Index extends React.Component<EmptyProps, State> {
             return 0;
           }),
       });
-      if (listBlogSeries.data.listBlogSeriess.nextToken != null)
+      if (listBlogSeries?.data?.listBlogSeriess?.nextToken)
         this.listBlogSeries(listBlogSeries.data.listBlogSeriess.nextToken);
     } catch (e) {
       console.error(e);
@@ -222,35 +237,37 @@ class Index extends React.Component<EmptyProps, State> {
 
   // HANDLERS
 
-  handlePublishDate = (date: any) => {
+  handlePublishDate = (date: Date) => {
     this.setState({
       publishDate: date,
     });
+    this.updateBlogField('publishedDate', format(date, 'yyyy-MM-dd'));
   };
 
-  handleExpireDate = (date: any) => {
+  handleExpireDate = (date: Date) => {
     this.setState({
       expireDate: date,
     });
+    this.updateBlogField('expirationDate', format(date, 'yyyy-MM-dd'));
   };
 
   async handleDeleteBlogPost() {
     if (this.state.understand === this.deleteConfirmation) {
       try {
-        const deleteBlog: any = await API.graphql({
+        const deleteBlog = (await API.graphql({
           query: mutations.deleteBlog,
           variables: { input: { id: this.state.delete } },
           authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-        });
+        })) as GraphQLResult<DeleteBlogMutation>;
 
         console.log({ 'Success mutations.deleteBlog: ': deleteBlog });
         this.setState({
           delete: '',
           understand: '',
-          showAlert: `⚠️ Deleted: ${deleteBlog.data.deleteBlog.id}`,
+          showAlert: `⚠️ Deleted: ${deleteBlog?.data?.deleteBlog?.id}`,
         });
       } catch (e) {
-        if (e.data && e.data.deleteBlog) {
+        if (e.data?.deleteBlog) {
           this.setState({
             delete: '',
             understand: '',
@@ -267,21 +284,21 @@ class Index extends React.Component<EmptyProps, State> {
   async handleDeleteBlogSeries() {
     if (this.state.understandBlogSeries === this.deleteConfirmation) {
       try {
-        const deleteBlogSeries: any = await API.graphql({
+        const deleteBlogSeries = (await API.graphql({
           query: mutations.deleteBlogSeries,
           variables: { input: { id: this.state.deleteBlogSeries } },
           authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-        });
+        })) as GraphQLResult<DeleteBlogSeriesMutation>;
         console.log({
           'Success mutations.deleteBlogSeries: ': deleteBlogSeries,
         });
         this.setState({
           deleteBlogSeries: '',
           understandBlogSeries: '',
-          showAlert: `⚠️ Deleted: ${deleteBlogSeries.data.deleteBlogSeries.id} `,
+          showAlert: `⚠️ Deleted: ${deleteBlogSeries?.data?.deleteBlogSeries?.id} `,
         });
       } catch (e) {
-        if (e.data && e.data.deleteBlogSeries) {
+        if (e.data?.deleteBlogSeries) {
           this.setState({
             deleteBlogSeries: '',
             understandBlogSeries: '',
@@ -297,10 +314,10 @@ class Index extends React.Component<EmptyProps, State> {
 
   async handleSave() {
     if (
-      this.state.title === '' ||
-      this.state.author === '' ||
-      this.state.desc === '' ||
-      this.state.editorState.getCurrentContent().hasText() === false
+      !this.state.blogObject.blogTitle ||
+      !this.state.blogObject.author ||
+      !this.state.blogObject.description ||
+      !this.state.editorState.getCurrentContent().hasText()
     ) {
       this.setState({
         showAlert:
@@ -308,36 +325,20 @@ class Index extends React.Component<EmptyProps, State> {
       });
       return false;
     }
-    const titles: any = [];
-    this.state.blogPostsList.forEach((post: any) => {
-      titles.push(post.blogTitle);
+    const titles: string[] = [];
+    this.state.blogPostsList.forEach((post) => {
+      if (post?.blogTitle) titles.push(post?.blogTitle);
     });
     const contentState = this.state.editorState.getCurrentContent();
     const raw = convertToRaw(contentState);
     const html = draftToHtml(raw);
     this.updateBlogField('content', html);
-    if (this.state.selectedVideoSeries) {
-      // DynamoDB naming convention is confusing blog(videoSeries)Id
-      this.updateBlogField('blogSeriesId', this.state.selectedVideoSeries);
-    } else {
-      this.updateBlogField('blogSeriesId', 'nonEmptyVoidStringValue');
-    }
-    this.updateBlogField(
-      'publishedDate',
-      format(this.state.publishDate, 'yyyy-MM-dd')
-    );
+    this.updateBlogField('id', this.state.blogObject.blogTitle);
 
-    if (this.state.disableCalendar === true) {
-      this.updateBlogField('expirationDate', 'none');
-    } else {
-      this.updateBlogField(
-        'expirationDate',
-        format(this.state.expireDate, 'yyyy-MM-dd')
-      );
-    }
-    console.log(this.state.blogObject);
-
-    if (this.state.editMode === false && titles.includes(this.state.title)) {
+    if (
+      !this.state.editMode &&
+      titles.includes(this.state.blogObject?.blogTitle)
+    ) {
       this.setState({
         showAlert:
           '⚠️ Warning: A post with this title exists. Please change your title. If you are trying to edit this post, please close this message then click edit: Edit an existing post',
@@ -345,9 +346,6 @@ class Index extends React.Component<EmptyProps, State> {
       return false;
     }
 
-    this.updateBlogField('blogStatus', this.state.blogStatus);
-    this.updateBlogField('tags', this.state.selectedTags);
-    this.updateBlogField('blogStatus', this.state.blogStatus);
     this.writeBridges(
       this.state.selectedBlogSeries,
       this.state.deselectedBlogSeries
@@ -356,33 +354,33 @@ class Index extends React.Component<EmptyProps, State> {
     this.setState({ editMode: true });
 
     try {
-      const updateBlog: any = await API.graphql({
+      const updateBlog = (await API.graphql({
         query: mutations.updateBlog,
         variables: { input: this.state.blogObject },
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      });
+      })) as GraphQLResult<UpdateBlogMutation>;
       this.setState({
-        showAlert: `✅ Saved: ${updateBlog.data.updateBlog.id}`,
+        showAlert: `✅ Saved: ${updateBlog?.data?.updateBlog?.id}`,
       });
       console.log({ 'Success mutations.updateBlog: ': updateBlog });
     } catch (e) {
-      if (e.data && e.data.updateBlog) {
-        this.setState({ showAlert: `✅ Saved: ${e.data.updateBlog.id}` });
+      if (e.data?.updateBlog) {
+        this.setState({ showAlert: `✅ Saved: ${e.data?.updateBlog?.id}` });
       }
       console.error(e);
       try {
-        const createBlog: any = await API.graphql({
+        const createBlog = (await API.graphql({
           query: mutations.createBlog,
           variables: { input: this.state.blogObject },
           authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-        });
+        })) as GraphQLResult<CreateBlogMutation>;
         this.setState({
-          showAlert: `✅ Created: ${createBlog.data.createBlog.id}`,
+          showAlert: `✅ Created: ${createBlog?.data?.createBlog?.id}`,
         });
         console.log({ 'Success mutations.createBlog: ': createBlog });
       } catch (e) {
-        if (e.data && e.data.createBlog) {
-          this.setState({ showAlert: `✅ Created: ${e.data.createBlog.id}` });
+        if (e.data?.createBlog) {
+          this.setState({ showAlert: `✅ Created: ${e.data?.createBlog?.id}` });
         }
         console.error(e);
       }
@@ -400,69 +398,66 @@ class Index extends React.Component<EmptyProps, State> {
 
   async handleEdit() {
     this.setState({ showEditModal: true });
-    await this.waitForSelection(() => this.state.blogToEditObject);
-    console.log(this.state.blogToEditObject);
-    const blocksfromHtml = htmlToDraft(this.state.blogToEditObject.content);
-    const { contentBlocks, entityMap } = blocksfromHtml;
-    const contentState = ContentState.createFromBlockArray(
-      contentBlocks,
-      entityMap
-    );
-    this.setState({
-      title: this.state.blogToEditObject.blogTitle,
-      author: this.state.blogToEditObject.author,
-      desc: this.state.blogToEditObject.description,
-      editorState: EditorState.createWithContent(contentState),
-      selectedTags: this.state.blogToEditObject.tags,
-      blogStatus: this.state.blogToEditObject.blogStatus,
-    });
+    await this.waitForSelection(() => Boolean(this.state.blogToEditObject));
 
-    this.updateBlogField('blogTitle', this.state.title); // sets id so other functions work
+    if (this.state.blogToEditObject?.content) {
+      const blocksfromHtml = htmlToDraft(this.state.blogToEditObject?.content);
+      const { contentBlocks, entityMap } = blocksfromHtml;
+      const contentState = ContentState.createFromBlockArray(
+        contentBlocks,
+        entityMap
+      );
+      this.setState({
+        editorState: EditorState.createWithContent(contentState),
+      });
 
-    if (this.state.blogToEditObject.expirationDate !== 'none') {
-      const exp = parse(
-        this.state.blogToEditObject.expirationDate,
+      this.setState({ blogObject: this.state.blogToEditObject });
+
+      if (
+        this.state.blogToEditObject.expirationDate !== 'none' &&
+        this.state.blogToEditObject.expirationDate
+      ) {
+        const exp = parse(
+          this.state.blogToEditObject.expirationDate,
+          'yyyy-MM-dd',
+          new Date()
+        );
+        this.setState({ expireDate: exp, disableCalendar: false });
+      }
+    }
+
+    if (this.state.blogToEditObject?.publishedDate) {
+      const pub = parse(
+        this.state.blogToEditObject?.publishedDate,
         'yyyy-MM-dd',
         new Date()
       );
-      this.setState({ expireDate: exp, disableCalendar: false });
+      this.setState({ publishDate: pub });
     }
 
-    const pub = parse(
-      this.state.blogToEditObject.publishedDate,
-      'yyyy-MM-dd',
-      new Date()
-    );
-    this.setState({ publishDate: pub });
-
-    if (this.state.blogToEditObject.series) {
-      this.setState({
-        selectedVideoSeries: this.state.blogToEditObject.series.id,
-      });
-    }
-
-    const blogBridgeByPost: any = API.graphql({
+    const blogBridgeByPost = API.graphql({
       query: queries.blogBridgeByPost,
-      variables: { blogPostID: this.state.blogToEditObject.id },
+      variables: { blogPostID: this.state.blogToEditObject?.id ?? '' },
       authMode: GRAPHQL_AUTH_MODE.API_KEY,
-    });
+    }) as Promise<GraphQLResult<BlogBridgeByPostQuery>>;
     blogBridgeByPost
-      .then((json: any) => {
+      .then((json) => {
         console.log({ 'Success queries.blogBridgeByPost: ': json });
-        console.log(json);
         this.setState({
-          blogBridgeList: json.data.blogBridgeByPost.items,
+          blogBridgeList: json?.data?.blogBridgeByPost?.items ?? [],
         });
-        this.state.blogBridgeList.forEach((bridge: any) =>
-          this.setState({
-            selectedBlogSeries: this.state.selectedBlogSeries.concat(
-              bridge.blogSeriesID
-            ),
-          })
-        );
+        if (this.state.blogBridgeList)
+          this.state.blogBridgeList.forEach((bridge) => {
+            if (bridge?.blogSeriesID)
+              this.setState({
+                selectedBlogSeries: this.state.selectedBlogSeries.concat(
+                  bridge.blogSeriesID
+                ),
+              });
+          });
       })
-      .catch((e: any) => {
-        console.log(e);
+      .catch((e) => {
+        console.error(e);
       });
 
     this.setState({ editMode: true });
@@ -470,42 +465,41 @@ class Index extends React.Component<EmptyProps, State> {
 
   async handleNewBlogSeries() {
     this.setState({ newBlogSeriesModal: false });
-    if (this.state.newBlogSeries.title !== '') {
+    if (this.state.newBlogSeries.title) {
+      this.updateSeriesField('id', this.state.newBlogSeries.title);
       try {
-        const saveBlogSeries: any = await API.graphql({
+        const saveBlogSeries = (await API.graphql({
           query: mutations.createBlogSeries,
           variables: { input: this.state.newBlogSeries },
           authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-        });
+        })) as GraphQLResult<CreateBlogSeriesMutation>;
         console.log({ 'Success mutations.createBlogSeries: ': saveBlogSeries });
         this.setState({
-          showAlert: `✅ Created blog series: ${saveBlogSeries.data.saveBlogSeries.id}`,
+          showAlert: `✅ Created blog series: ${saveBlogSeries?.data?.createBlogSeries?.id}`,
         });
       } catch (e) {
-        if (e.data && e.data.createBlogSeries)
+        if (e.data?.createBlogSeries)
           this.setState({
-            showAlert: `✅ Created blog series: ${e.data.createBlogSeries.id}`,
+            showAlert: `✅ Created blog series: ${e.data?.createBlogSeries?.id}`,
           });
         console.error(e);
       }
     }
   }
 
-  updateSeriesField(field: any, value: any) {
-    const blogSeries = this.state.newBlogSeries;
-    blogSeries[field] = value;
-
-    blogSeries.id = blogSeries.title;
-    this.setState({ newBlogSeries: blogSeries });
-    console.log(blogSeries);
+  updateSeriesField(field: keyof CreateBlogSeriesInput, value: string) {
+    this.setState((prevState) => ({
+      newBlogSeries: { ...prevState.newBlogSeries, [field]: value },
+    }));
   }
 
-  updateBlogField(field: any, value: any) {
-    const blog = this.state.blogObject;
-    blog[field] = value;
-
-    blog.id = blog.blogTitle;
-    this.setState({ blogObject: blog });
+  updateBlogField(
+    field: keyof CreateBlogInput,
+    value: boolean | string | (string | null)[]
+  ) {
+    this.setState((prevState) => ({
+      blogObject: { ...prevState.blogObject, [field]: value },
+    }));
   }
 
   writeBridges(toAdd: string[], toDelete: string[]) {
@@ -514,17 +508,17 @@ class Index extends React.Component<EmptyProps, State> {
     toDelete.forEach((series: string) => {
       const bridgeID = currentPostID + '-' + series;
 
-      const deleteBlogSeriesBridge: any = API.graphql({
+      const deleteBlogSeriesBridge = API.graphql({
         query: mutations.deleteBlogSeriesBridge,
         variables: { input: { id: bridgeID } },
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      });
+      }) as Promise<GraphQLResult<DeleteBlogSeriesBridgeMutation>>;
 
       deleteBlogSeriesBridge
-        .then((json: any) => {
+        .then((json) => {
           console.log({ 'Success mutations.deleteBlogSeriesBridge: ': json });
         })
-        .catch((e: any) => {
+        .catch((e) => {
           console.error(e);
         });
     });
@@ -532,7 +526,7 @@ class Index extends React.Component<EmptyProps, State> {
     toAdd.forEach((series: string) => {
       const bridgeID = currentPostID + '-' + series;
 
-      const createBlogSeriesBridge: any = API.graphql({
+      const createBlogSeriesBridge = API.graphql({
         query: mutations.createBlogSeriesBridge,
         variables: {
           input: {
@@ -542,14 +536,14 @@ class Index extends React.Component<EmptyProps, State> {
           },
         },
         authMode: GRAPHQL_AUTH_MODE.AMAZON_COGNITO_USER_POOLS,
-      });
+      }) as Promise<GraphQLResult<CreateBlogSeriesBridgeMutation>>;
 
       createBlogSeriesBridge
-        .then((json: any) => {
+        .then((json) => {
           console.log({ 'Success mutations.createBlogSeriesBridge: ': json });
         })
-        .catch((e: any) => {
-          console.log(e);
+        .catch((e) => {
+          console.error(e);
         });
     });
   }
@@ -557,32 +551,36 @@ class Index extends React.Component<EmptyProps, State> {
   handleDeleteBridge() {
     const removed = this.state.selectedBlogSeries;
     const toDelete = removed.pop();
-    this.setState({
-      selectedBlogSeries: removed,
-      deselectedBlogSeries: this.state.deselectedBlogSeries.concat(toDelete),
-    });
+    if (toDelete) {
+      this.setState({
+        selectedBlogSeries: removed,
+        deselectedBlogSeries: this.state.deselectedBlogSeries.concat(toDelete),
+      });
+    }
   }
 
   handleAddBridge() {
-    this.setState({
-      selectedBlogSeries: this.state.selectedBlogSeries.concat(
-        this.state.currentBlogSeries
-      ),
-      deselectedBlogSeries: this.state.deselectedBlogSeries.filter(
-        (elem: any) => elem !== this.state.currentBlogSeries
-      ),
-    });
+    if (this.state.currentBlogSeries) {
+      this.setState({
+        selectedBlogSeries: this.state.selectedBlogSeries.concat(
+          this.state.currentBlogSeries
+        ),
+        deselectedBlogSeries: this.state.deselectedBlogSeries.filter(
+          (elem) => elem !== this.state.currentBlogSeries
+        ),
+      });
+    }
   }
 
-  handleRemoveTag(item: string) {
-    this.setState({
-      selectedTags: this.state.selectedTags.filter(
-        (elem: any) => elem !== item
-      ),
-    });
+  handleRemoveTag(item: string | null) {
+    if (item)
+      this.updateBlogField(
+        'tags',
+        this.state.blogObject?.tags?.filter((elem) => elem !== item) ?? []
+      );
   }
 
-  onChange = (editorState: any) => this.setState({ editorState });
+  onChange = (editorState: EditorState) => this.setState({ editorState });
 
   // RENDER FUNCTIONS
 
@@ -591,17 +589,17 @@ class Index extends React.Component<EmptyProps, State> {
       <Modal isOpen={this.state.showEditModal}>
         <div>Edit a blog post</div>
         <select
-          onChange={(event: any) =>
-            this.setState({ blogToEditID: event.target.value })
+          onChange={(event) =>
+            this.setState({ blogToEditId: event.target.value })
           }
         >
           <option key="null" value="null">
             None Selected
           </option>
-          {this.state.blogPostsList.map((item: any) => {
+          {this.state.blogPostsList.map((item) => {
             return (
-              <option key={item.id} value={item.id}>
-                {item.id}
+              <option key={item?.id} value={item?.id}>
+                {item?.id}
               </option>
             );
           })}
@@ -611,7 +609,7 @@ class Index extends React.Component<EmptyProps, State> {
             this.setState({
               showEditModal: false,
               blogToEditObject: this.state.blogPostsList.filter(
-                (post: any) => post.id === this.state.blogToEditID
+                (post) => post?.id === this.state.blogToEditId
               )[0],
             })
           }
@@ -629,8 +627,8 @@ class Index extends React.Component<EmptyProps, State> {
         <label>
           Title:
           <input
-            value={this.state.newBlogSeries.title}
-            onChange={(item: any) => {
+            value={this.state.newBlogSeries.title ?? ''}
+            onChange={(item) => {
               this.updateSeriesField('title', item.target.value);
             }}
           />
@@ -646,8 +644,8 @@ class Index extends React.Component<EmptyProps, State> {
         <b>Blog Status</b>
         <select
           style={{ width: 200 }}
-          onChange={(event: any) =>
-            this.setState({ blogStatus: event.target.value })
+          onChange={(event) =>
+            this.updateBlogField('blogStatus', event.target.value)
           }
         >
           <option key="null" value="null">
@@ -660,7 +658,7 @@ class Index extends React.Component<EmptyProps, State> {
             Live
           </option>
         </select>
-        <div>Current status: {this.state.blogStatus}</div>
+        <div>Current status: {this.state.blogObject.blogStatus}</div>
         <br />
 
         <label>
@@ -668,40 +666,39 @@ class Index extends React.Component<EmptyProps, State> {
           <input
             type="text"
             value={this.state.currentTag}
-            onChange={(event: any) =>
+            onChange={(event) =>
               this.setState({ currentTag: event.target.value })
             }
           />
         </label>
         <button
           className="tags-button"
-          onClick={() =>
-            this.setState({
-              selectedTags: this.state.selectedTags.concat(
-                this.state.currentTag
-              ),
-              currentTag: '',
-            })
-          }
+          onClick={() => {
+            this.updateBlogField(
+              'tags',
+              this.state.blogObject.tags?.concat(this.state.currentTag) ?? []
+            );
+            this.setState({ currentTag: '' });
+          }}
         >
           Confirm Tag
         </button>
         <button
           className="tags-button"
           style={{ background: 'red' }}
-          onClick={() => this.setState({ selectedTags: [] })}
+          onClick={() => this.updateBlogField('tags', [])}
         >
           Clear All Tags
         </button>
         <div>
           <b>Current tags (click on tag to delete):</b>
-          {this.state.selectedTags.map((item: any, index: number) => (
+          {this.state.blogObject?.tags?.map((item, index: number) => (
             <div
               key={index}
               className="tags-item"
               onClick={() => this.handleRemoveTag(item)}
             >
-              {index === this.state.selectedTags.length - 1
+              {index === (this.state.blogObject?.tags?.length ?? 0) - 1
                 ? item
                 : item + ', '}
             </div>
@@ -729,17 +726,17 @@ class Index extends React.Component<EmptyProps, State> {
         </button>
         <select
           style={{ width: 800 }}
-          onChange={(event: any) =>
+          onChange={(event) =>
             this.setState({ currentBlogSeries: event.target.value })
           }
         >
           <option key="null" value="null">
             None Selected
           </option>
-          {this.state.blogSeriesList.map((item: any) => {
+          {this.state.blogSeriesList.map((item) => {
             return (
-              <option key={item.id} value={item.id}>
-                {item.title}
+              <option key={item?.id} value={item?.id}>
+                {item?.title}
               </option>
             );
           })}
@@ -757,34 +754,24 @@ class Index extends React.Component<EmptyProps, State> {
         <b>Add to Video Series</b>
         <button
           className="tags-button"
-          onClick={() =>
-            this.setState({
-              selectedVideoSeries: this.state.currentVideoSeries,
-            })
-          }
-        >
-          Select
-        </button>
-        <button
-          className="tags-button"
           style={{ background: 'red' }}
-          onClick={() => this.setState({ selectedVideoSeries: null })}
+          onClick={() => this.updateBlogField('blogSeriesId', this.nullString)}
         >
           Clear
         </button>
         <select
           style={{ width: 800 }}
-          onChange={(event: any) =>
-            this.setState({ currentVideoSeries: event.target.value })
+          onChange={(event) =>
+            this.updateBlogField('blogSeriesId', event.target.value)
           }
         >
           <option key="null" value="null">
             None Selected
           </option>
-          {this.state.videoSeriesList.map((item: any) => {
+          {this.state.videoSeriesList.map((item) => {
             return (
-              <option key={item.id} value={item.id}>
-                {item.id}
+              <option key={item?.id} value={item?.id}>
+                {item?.id}
               </option>
             );
           })}
@@ -792,7 +779,9 @@ class Index extends React.Component<EmptyProps, State> {
         <div>
           <b>Current video series: </b>{' '}
           <div style={{ display: 'inline' }}>
-            {this.state.selectedVideoSeries}{' '}
+            {this.state.blogObject.blogSeriesId === this.nullString
+              ? ''
+              : this.state.blogObject.blogSeriesId}
           </div>
         </div>
         <br />
@@ -832,9 +821,7 @@ class Index extends React.Component<EmptyProps, State> {
             style={{ width: 400, height: 20 }}
             type="text"
             value={this.state.delete}
-            onChange={(event: any) =>
-              this.setState({ delete: event.target.value })
-            }
+            onChange={(event) => this.setState({ delete: event.target.value })}
           />
         </label>
         <label>
@@ -843,7 +830,7 @@ class Index extends React.Component<EmptyProps, State> {
             style={{ width: 400, height: 20 }}
             type="text"
             value={this.state.understand}
-            onChange={(event: any) =>
+            onChange={(event) =>
               this.setState({ understand: event.target.value })
             }
           />
@@ -863,7 +850,7 @@ class Index extends React.Component<EmptyProps, State> {
             style={{ width: 400, height: 20 }}
             type="text"
             value={this.state.deleteBlogSeries}
-            onChange={(event: any) =>
+            onChange={(event) =>
               this.setState({ deleteBlogSeries: event.target.value })
             }
           />
@@ -874,7 +861,7 @@ class Index extends React.Component<EmptyProps, State> {
             style={{ width: 400, height: 20 }}
             type="text"
             value={this.state.understandBlogSeries}
-            onChange={(event: any) =>
+            onChange={(event) =>
               this.setState({ understandBlogSeries: event.target.value })
             }
           />
@@ -898,14 +885,13 @@ class Index extends React.Component<EmptyProps, State> {
           <input
             className="small-input"
             type="text"
-            value={this.state.title}
-            onChange={(event: any) => {
+            value={this.state.blogObject.blogTitle ?? ''}
+            onChange={(event) => {
+              this.updateBlogField('blogTitle', event.target.value);
               this.setState({
-                title: event.target.value,
                 selectedBlogSeries: [],
                 editMode: false,
               });
-              this.updateBlogField('blogTitle', event.target.value);
             }}
           />
         </label>
@@ -915,9 +901,8 @@ class Index extends React.Component<EmptyProps, State> {
           <input
             className="small-input"
             type="text"
-            value={this.state.author}
-            onChange={(event: any) => {
-              this.setState({ author: event.target.value });
+            value={this.state.blogObject.author ?? ''}
+            onChange={(event) => {
               this.updateBlogField('author', event.target.value);
             }}
           />
@@ -930,21 +915,33 @@ class Index extends React.Component<EmptyProps, State> {
 
         <label
           style={
-            this.state.desc.length >= 175
+            this.state.blogObject?.description &&
+            this.state.blogObject.description?.length >= 175
               ? { color: 'red' }
               : { color: 'black' }
           }
         >
-          Description ({this.state.desc.length + ' of 200 characters'}):
+          Description (
+          {this.state.blogObject.description?.length + ' of 200 characters'}):
           <textarea
             className="big-input"
             maxLength={200}
-            value={this.state.desc}
-            onChange={(event: any) => {
-              this.setState({ desc: event.target.value });
-              this.updateBlogField('description', this.state.desc);
+            value={this.state.blogObject.description ?? ''}
+            onChange={(event) => {
+              this.updateBlogField('description', event.target.value);
             }}
           />
+        </label>
+
+        <label>
+          Hide from main index
+          <input
+            type="checkbox"
+            checked={this.state.blogObject.hiddenMainIndex ?? false}
+            onChange={(e) =>
+              this.updateBlogField('hiddenMainIndex', e.target.checked)
+            }
+          ></input>
         </label>
 
         <Editor


### PR DESCRIPTION
Blogs were sorting inconsistently in different components.

Edit: 
- Refactor `create-blog.tsx`
- Add checkbox to admin page to allow hiding posts from main blog index (resolves feature request in #236) 
- Update appropriate queries with the following filter: `filter: { hiddenMainIndex: { ne: true } }` 