### PR TITLE
Blog: add similar posts component to blog reader

### DIFF
--- a/public/static/content/blog-post.json
+++ b/public/static/content/blog-post.json
@@ -17,6 +17,15 @@
       {
         "type": "post",
         "style": "blog"
+      },
+      {
+        "type": "list",
+        "header1": "Similar Blog Posts",
+        "class": "blogs",
+        "style": "blogs",
+        "selector": "similar",
+        "status": "Live",
+        "sortOrder": "DESC"
       }
     ]
   }

--- a/public/static/content/blog.json
+++ b/public/static/content/blog.json
@@ -38,6 +38,7 @@
         "type": "list",
         "class": "blogs",
         "style": "blogs",
+        "selector": "all",
         "status": "Live",
         "sortOrder": "DESC",
         "skipFirstPost": true

--- a/src/components/RenderRouter/DataLoader.ts
+++ b/src/components/RenderRouter/DataLoader.ts
@@ -24,6 +24,9 @@ import {
   ListCustomPlaylistsQueryVariables,
   ListF1ListGroup2sQuery,
   ListF1ListGroup2sQueryVariables,
+  GetBlogQuery,
+  SearchBlogsQuery,
+  SearchBlogsQueryVariables,
 } from '../../API';
 
 Amplify.configure(awsmobile);
@@ -83,7 +86,8 @@ export interface SpeakerQuery extends DataLoaderQuery {
 
 export interface BlogQuery extends DataLoaderQuery {
   class: 'blogs';
-  status: string;
+  status: 'Live' | 'Unlisted';
+  selector: 'all' | 'similar';
   sortOrder: ModelSortDirection;
 }
 
@@ -482,6 +486,58 @@ export default class DataLoader {
       if (nextToken) {
         await this.getSpeakers(query, dataLoaded, nextToken);
       }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+
+  static async getSimilarBlogs(
+    query: BlogQuery,
+    postId: string,
+    dataLoaded: OnDataListener<BlogData[]>
+  ): Promise<void> {
+    const getBlog = (await API.graphql(
+      graphqlOperation(customQueries.getBlogForSearch, { id: postId })
+    )) as GraphQLResult<GetBlogQuery>;
+
+    const blogTags = getBlog.data?.getBlog?.tags?.filter(
+      (tag) => !['The Meeting House', 'church'].includes(tag ?? '')
+    );
+
+    let blogTag1;
+    let blogTag2;
+    let blogTag3;
+    if (blogTags?.length && blogTags.length > 0) {
+      blogTag1 = blogTags[0] ?? '';
+      blogTag2 = blogTags[1] ?? '';
+      blogTag3 = blogTags[2] ?? '';
+    }
+
+    const blogAuthor = getBlog.data?.getBlog?.author;
+
+    const vars: SearchBlogsQueryVariables = {
+      limit: 3,
+      filter: {
+        id: { ne: postId },
+        blogStatus: { eq: query.status },
+        or: [
+          { author: { matchPhrase: blogAuthor } },
+          { tags: { matchPhrase: blogTag1 } },
+          { tags: { matchPhrase: blogTag2 } },
+          { tags: { matchPhrase: blogTag3 } },
+          { description: { matchPhrase: blogTag1 } },
+        ],
+      },
+    };
+    const searchBlogs = API.graphql(
+      graphqlOperation(customQueries.searchBlogs, vars)
+    ) as Promise<GraphQLResult<SearchBlogsQuery>>;
+    try {
+      const json = await searchBlogs;
+      console.debug('Success customQueries.searchBlogs: ' + json);
+      console.debug(json);
+
+      dataLoaded(json?.data?.searchBlogs?.items ?? []);
     } catch (e) {
       console.error(e);
     }

--- a/src/components/RenderRouter/ListItem.scss
+++ b/src/components/RenderRouter/ListItem.scss
@@ -120,6 +120,14 @@
     color: $coolgray11;
   }
 
+  .BlogItemH1 {
+    font-weight: bold;
+    font-size: 2vw;
+    margin-bottom: 2vw;
+    font-family: Graphik Web;
+    color: $onyxblacktext;
+  }
+
   .ListItemH1 {
     position: relative;
     left: 0vw;
@@ -737,6 +745,14 @@
     width: 80vw;
     font-weight: bold;
     font-size: 3vw;
+    color: $onyxblacktext;
+  }
+
+  .BlogItemH1 {
+    font-weight: bold;
+    font-size: 2vw;
+    margin-bottom: 2vw;
+    font-family: Graphik Web;
     color: $onyxblacktext;
   }
 
@@ -1438,6 +1454,15 @@
     font-size: 10vw;
     font-weight: 700;
     font-family: Graphik Web;
+  }
+
+  .BlogItemH1 {
+    font-weight: bold;
+    font-size: 8vw;
+    margin-bottom: 8vw;
+    font-family: Graphik Web;
+    color: $onyxblacktext;
+    width: 80vw;
   }
 
   .ListItemH1.whiteText {

--- a/src/components/RenderRouter/ListItem.tsx
+++ b/src/components/RenderRouter/ListItem.tsx
@@ -249,8 +249,15 @@ class ListItem extends React.Component<Props, State> {
         }
         break;
       case 'blogs':
-        await DataLoader.getBlogs(query, dataLoaded);
-        return;
+        switch (query.selector) {
+          case 'all':
+            await DataLoader.getBlogs(query, dataLoaded);
+            return;
+          case 'similar':
+            const postId = this.props?.match?.params?.blog ?? '';
+            await DataLoader.getSimilarBlogs(query, postId, dataLoaded);
+            return;
+        }
       case 'user-defined':
         return;
       default:
@@ -1295,12 +1302,19 @@ class ListItem extends React.Component<Props, State> {
           moment(post?.expirationDate, 'YYYY-MM-DD').isAfter(today)
       );
 
+      if (dateChecked.length === 0) {
+        return null;
+      }
+
       return (
-        <div className="ListItemDiv1 BlogItem">
-          <div className="BlogItemContainer">
-            {dateChecked.slice(startIndex).map((item: any, index: any) => {
-              return this.renderItemRouter(item, index);
-            })}
+        <div className="ListItemDiv1">
+          <h1 className="BlogItemH1">{this.state.content.header1}</h1>
+          <div className="BlogItem">
+            <div className="BlogItemContainer">
+              {dateChecked.slice(startIndex).map((item: any, index: any) => {
+                return this.renderItemRouter(item, index);
+              })}
+            </div>
           </div>
         </div>
       );

--- a/src/graphql-custom/customQueries.ts
+++ b/src/graphql-custom/customQueries.ts
@@ -299,6 +299,16 @@ export const getSeriesBySeriesType = `query GetSeriesBySeriesType(
 }
 `;
 
+export const getBlogForSearch = /* GraphQL */ `
+  query GetBlog($id: ID!) {
+    getBlog(id: $id) {
+      id
+      author
+      tags
+    }
+  }
+`;
+
 export const getBlog = /* GraphQL */ `
   query GetBlog($id: ID!) {
     getBlog(id: $id) {
@@ -568,6 +578,7 @@ export const searchBlogs = /* GraphQL */ `
     ) {
       items {
         id
+        author
         publishedDate
         expirationDate
         blogStatus


### PR DESCRIPTION
Per feature request in #236.

Matches blogs that share tags or author. Also, queries for matches between current blog's tags and other the description of other blogs. Limit of three similar posts.