### PR TITLE
Allow the user to filter home churches based on their current location

### DIFF
--- a/public/static/svg/FindMyLocation.svg
+++ b/public/static/svg/FindMyLocation.svg
@@ -1,0 +1,21 @@
+<!--
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+Modifications: changed path color
+-->
+<svg xmlns="http://www.w3.org/2000/svg" height="24" viewBox="0 0 24 24" width="24">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M12 8c-2.21 0-4 1.79-4 4s1.79 4 4 4 4-1.79 4-4-1.79-4-4-4zm8.94 3c-.46-4.17-3.77-7.48-7.94-7.94V1h-2v2.06C6.83 3.52 3.52 6.83 3.06 11H1v2h2.06c.46 4.17 3.77 7.48 7.94 7.94V23h2v-2.06c4.17-.46 7.48-3.77 7.94-7.94H23v-2h-2.06zM12 19c-3.87 0-7-3.13-7-7s3.13-7 7-7 7 3.13 7 7-3.13 7-7 7z" fill="#54565A"/>
+</svg>

--- a/src/components/RenderRouter/HomeChurchItem.scss
+++ b/src/components/RenderRouter/HomeChurchItem.scss
@@ -226,6 +226,12 @@
   }
 }
 
+.UpdateLocationButton {
+  border: 1px solid $coolgray11;
+  background-color: $body-bg;
+  border-radius: 2px;
+}
+
 @media (min-width: 768px) {
   .LoadingMargin {
     max-height: calc(88vh - 221px);


### PR DESCRIPTION
This seems a bit complicated, but there were a bunch of UX things I wanted to account for

- Make a seamless first load experience once the user has made their permissions choice, either granted or denied
- Keep the button present if the user has denied permissions, to remind them this feature exists and they may want to grant permission
- Filtering:
    - Limit the number of home churches shown on first load (I don't think showing everything is helpful)
    - Restrict the home churches to "Near Me" with a button press, assuming I'm not looking at some other city (no location filter exists)
    - If the user clicks "Near Me" after selecting a parish, show them how far away they are. *** This was the tricky one because simpler logic results in either no home churches being shown (none of the currently filtered ones are close so it's just super zoomed in on the dot), or the "Near Me" button is useless after filtering, which isn't great either.

Nearby radius is 20 kilometers. I don't know if this is the best though.