### PR TITLE
Blog: use <br> tag to force button to new line

### DIFF
--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -328,18 +328,17 @@ class BlogItem extends React.Component<Props, State> {
                     </div>
                   );
                 })}
-              {this.state.publishedOnly.length % 2 !== 0 &&
-              this.state.screenWidth >= 768 ? (
-                <div className="BlogMultiImageItem"></div>
-              ) : null}
               {!this.props.content.hideAllBlogsButton ? (
-                <LinkButton
-                  size="lg"
-                  className="inverted multiImageButton"
-                  to="/blog"
-                >
-                  View All Blogs
-                </LinkButton>
+                <>
+                  <br />
+                  <LinkButton
+                    size="lg"
+                    className="inverted multiImageButton"
+                    to="/blog"
+                  >
+                    View All Blogs
+                  </LinkButton>
+                </>
               ) : null}
             </div>
           </div>


### PR DESCRIPTION
In the blog mutliImage component, there's a bug where the button is on the right instead of the left (e.g. see https://www.themeetinghouse.com/christmas).

This fix uses a `<br/>` tag to force the button to a new line instead of using (broken) logic to add an extra `<div/>`.