### PR TITLE
Fix bugs in Bible class parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ amplify/mock-data
 src/version.js
 
 .eslintcache
+debug.log

--- a/src/pages/admin/__tests__/bible.spec.js
+++ b/src/pages/admin/__tests__/bible.spec.js
@@ -1,0 +1,157 @@
+import Bible from '../bible';
+
+const testData = [
+  { in: 'Matthew 7:21, 24-27', out: 'invalid' },
+  { in: 'Jon 3:16', out: 'invalid' },
+  {
+    in: 'Genesis 3',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/GEN.3.NIV`,
+      queryString: `GEN.3`,
+    },
+  },
+  {
+    in: 'Genesis 3-4',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/GEN.3.NIV`,
+      queryString: `GEN.3-GEN.4`,
+    },
+  },
+  {
+    in: 'Genesis 3:1-4',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/GEN.3.1-4.NIV`,
+      queryString: `GEN.3.1-GEN.3.4`,
+    },
+  },
+  {
+    in: 'Genesis 3:20-4:20',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/GEN.3.NIV`,
+      queryString: `GEN.3.20-GEN.4.20`,
+    },
+  },
+  {
+    in: '2 Peter 2',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/2PE.2.NIV`,
+      queryString: `2PE.2`,
+    },
+  },
+  {
+    in: '1 Corinthians 8:4',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/1CO.8.4.NIV`,
+      queryString: `1CO.8.4`,
+    },
+  },
+  {
+    in: '1 Timothy 6:3-4',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/1TI.6.3-4.NIV`,
+      queryString: `1TI.6.3-1TI.6.4`,
+    },
+  },
+  {
+    in: '1 Corinthians 8:10-9:7',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/1CO.8.NIV`,
+      queryString: `1CO.8.10-1CO.9.7`,
+    },
+  },
+  {
+    test: '1 Corinthians 8:10—9:7 (emdash)',
+    in: '1 Corinthians 8:10—9:7',
+    out: 'invalid',
+  },
+  {
+    test: 'Mark 7:1—2 (emdash)',
+    in: 'Mark 7:1—2',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians 8:10–9:7 (endash)',
+    in: '1 Corinthians 8:10–9:7',
+    out: 'invalid',
+  },
+  {
+    test: 'Mark 7:1–2 (endash)',
+    in: 'Mark 7:1–2',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians 8;10-9:7 (invalid character)',
+    in: '1 Corinthians 8;10-9:7',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians 8:10=9:7 (invalid character)',
+    in: '1 Corinthians 8:10=9:7',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians 8:10_9:7 (invalid character)',
+    in: '1 Corinthians 8:10_9:7',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians 8:10 - 9:7 (extra spaces)',
+    in: '1 Corinthians 8:10 - 9:7',
+    out: 'invalid',
+  },
+  {
+    test: '1 Corinthians  8:10-9:7 (extra space)',
+    in: '1 Corinthians  8:10-9:7',
+    out: 'invalid',
+  },
+  {
+    in: 'Song of Solomon 2:1',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/SNG.2.1.NIV`,
+      queryString: `SNG.2.1`,
+    },
+  },
+  {
+    in: 'Song of Songs 2:1',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/SNG.2.1.NIV`,
+      queryString: `SNG.2.1`,
+    },
+  },
+  {
+    in: 'Song 2:1',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/SNG.2.1.NIV`,
+      queryString: `SNG.2.1`,
+    },
+  },
+  {
+    in: 'Songs 2:1',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/SNG.2.1.NIV`,
+      queryString: `SNG.2.1`,
+    },
+  },
+  {
+    in: 'Solomon 2:1',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/SNG.2.1.NIV`,
+      queryString: `SNG.2.1`,
+    },
+  },
+  {
+    in: 'Psalms 128:6-130:4',
+    out: {
+      youVersionUri: `https://www.bible.com/bible/111/PSA.128.NIV`,
+      queryString: `PSA.128.6-PSA.130.4`,
+    },
+  },
+];
+
+describe('Parse Bible references and check for invalid strings', () => {
+  for (let data of testData) {
+    test(data.test ?? data.in, () => {
+      expect(Bible.getQueryString(data.in)).toEqual(data.out);
+    });
+  }
+});

--- a/src/pages/admin/bible.ts
+++ b/src/pages/admin/bible.ts
@@ -35,6 +35,7 @@ export default class Bible {
       ecclesiastes: 'ECC',
       solomon: 'SNG',
       song: 'SNG',
+      songs: 'SNG',
       isaiah: 'ISA',
       jeremiah: 'JER',
       lamentations: 'LAM',
@@ -81,16 +82,20 @@ export default class Bible {
       revelation: 'REV',
     };
 
-    console.debug(biblePassage);
-
-    const ref = biblePassage.trim().toLowerCase();
-    ref.replace('song of solomon', 'song');
+    let ref = biblePassage.trim().toLowerCase();
+    ref = ref.replace('song of solomon', 'song');
+    ref = ref.replace('song of songs', 'song');
     const colons = (ref.match(/:/g) || []).length;
     const hyphens = (ref.match(/-/g) || []).length;
     const spaces = (ref.match(/\s/g) || []).length;
 
+    const regex = RegExp(/[^\w :-]|_/g);
+
+    if (regex.test(ref)) {
+      return 'invalid';
+    }
+
     if (spaces !== 1 && spaces !== 2) {
-      console.error('invalid format');
       return 'invalid';
     }
 
@@ -105,7 +110,6 @@ export default class Bible {
       const code = bookCodes[temp[0]];
 
       if (!code) {
-        console.error('invalid format');
         return 'invalid';
       }
 
@@ -120,7 +124,6 @@ export default class Bible {
       const code = bookCodes[temp[0]];
 
       if (!code) {
-        console.error('invalid format');
         return 'invalid';
       }
 
@@ -134,7 +137,6 @@ export default class Bible {
       const code = bookCodes[temp[0]];
 
       if (!code) {
-        console.error('invalid format');
         return 'invalid';
       }
 
@@ -154,7 +156,6 @@ export default class Bible {
       const code = bookCodes[temp[0]];
 
       if (!code) {
-        console.error('invalid format');
         return 'invalid';
       }
 
@@ -177,7 +178,6 @@ export default class Bible {
       const code = bookCodes[temp[0]];
 
       if (!code) {
-        console.error('invalid format');
         return 'invalid';
       }
 
@@ -186,7 +186,6 @@ export default class Bible {
         queryString: `${code}.${verseChap1[0]}.${verseChap1[1]}-${code}.${verseChap2[0]}.${verseChap2[1]}`,
       };
     } else {
-      console.error('invalid format');
       return 'invalid';
     }
   }


### PR DESCRIPTION
Fixes bugs including #520.

Additional: 
- Create unit tests for Bible class
- Add `debug.log` to `.gitignore`