### PR TITLE
Update CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,17 +16,14 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12.x]
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+    - name: Use Node.js v14
+      uses: actions/setup-node@v2
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: '14.x'
     - name: Cache Node.js modules
       uses: actions/cache@v1
       with:
@@ -39,13 +36,8 @@ jobs:
     - name: Build
       run: npm ci
     - name: Test
-      run: npm test
+      run: npm test -- --coverage
     - name: Coveralls
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
-    - name: Archive code coverage results
-      uses: actions/upload-artifact@v1
-      with:
-        name: code-coverage-report
-        path: coverage/lcov-report/index.html


### PR DESCRIPTION
- Add coverage flag (Coveralls will fail without this)
- Remove code coverage archive (since we use Coveralls)
- Upgrade to actions/setup-node@v2, Node.js v14 (active LTS)

Should be consistent with [themeetinghouse/mobile](https://github.com/themeetinghouse/mobile).