### PR TITLE
Fix Lambda environment variable

### DIFF
--- a/amplify/backend/function/tmhnotespdf/src/index.js
+++ b/amplify/backend/function/tmhnotespdf/src/index.js
@@ -23,7 +23,7 @@ exports.handler = async (event) => {
   try {
     const groups = await cognito
       .adminListGroupsForUser({
-        UserPoolId: process.env.COGNITO_USER_POOL_ID,
+        UserPoolId: process.env.AUTH_COGNITODEVTMH_USERPOOLID,
         Username: event.arguments.userId,
       })
       .promise();


### PR DESCRIPTION
~~Authorization rules are handled at the schema level instead of in the Lambda itself.~~

Edit: apparently this isn't recommended. Back to the original fix.