### PR TITLE
Admin UI, Livestream: add local teaching button, refactoring + query fix

### DIFF
--- a/src/pages/admin/livestream.tsx
+++ b/src/pages/admin/livestream.tsx
@@ -108,6 +108,7 @@ interface State {
   livestreamList: Livestreams;
   liveObject: NewLivestream;
   customEvent: boolean;
+  lastZoomData: ZoomItem[] | null;
 }
 
 class Index extends React.Component<EmptyProps, State> {
@@ -121,8 +122,28 @@ class Index extends React.Component<EmptyProps, State> {
       livestreamList: [],
       liveObject: { ...liveInit },
       customEvent: false,
+      lastZoomData: null,
     };
-    this.listLivestreams();
+  }
+
+  async componentDidMount() {
+    await this.listLivestreams();
+
+    const lastLocalTeaching = this.state.livestreamList?.find(
+      (livestream) =>
+        // has zoom links
+        livestream?.zoom?.length &&
+        // has several zoom links
+        livestream?.zoom?.length > 12 &&
+        // is a sunday
+        moment(livestream?.date).isoWeekday() === 7 &&
+        // must include oakville
+        livestream.zoom.some(
+          (zoomItem) => zoomItem?.title.toLowerCase() === 'oakville'
+        )
+    );
+
+    this.setState({ lastZoomData: lastLocalTeaching?.zoom ?? null });
   }
 
   async listLivestreams(): Promise<void> {
@@ -996,7 +1017,25 @@ class Index extends React.Component<EmptyProps, State> {
               >
                 After Party Menu
               </button>
-
+              {this.state.lastZoomData ? (
+                <button
+                  style={{
+                    background: 'black',
+                    color: 'white',
+                    border: 0,
+                    height: 50,
+                    fontSize: 12,
+                    padding: 5,
+                  }}
+                  onClick={() =>
+                    this.handleChange('zoom', [
+                      ...(this.state.lastZoomData as ZoomItem[]),
+                    ])
+                  }
+                >
+                  Local Teaching
+                </button>
+              ) : null}
               {this.state.liveObject.zoom ? (
                 <button
                   style={{

--- a/src/pages/admin/livestream.tsx
+++ b/src/pages/admin/livestream.tsx
@@ -16,6 +16,7 @@ import {
   CreateLivestreamMutationVariables,
   DeleteLivestreamMutation,
   ListLivestreamsQuery,
+  ListLivestreamsQueryVariables,
   UpdateLivestreamMutation,
 } from 'API';
 import './livestream.scss';
@@ -147,13 +148,19 @@ class Index extends React.Component<EmptyProps, State> {
   }
 
   async listLivestreams(): Promise<void> {
+    const variables: ListLivestreamsQueryVariables = {
+      filter: {
+        date: { gt: moment().subtract(1, 'years').format('YYYY-MM-DD') },
+      },
+    };
+
     try {
       const listLivestreams = (await API.graphql({
         query: queries.listLivestreams,
-        variables: { limit: 52 },
+        variables,
         authMode: GRAPHQL_AUTH_MODE.API_KEY,
       })) as GraphQLResult<ListLivestreamsQuery>;
-      console.log({ 'Success queries.listCustomPlaylist': listLivestreams });
+      console.log({ 'Success queries.listLivestreams': listLivestreams });
       this.setState({
         livestreamList: (
           listLivestreams.data?.listLivestreams?.items ?? []


### PR DESCRIPTION
The local teaching button auto-fills the Zoom links with (what the code thinks are) the links from the last local teaching; see inline comments for logic. Closes #671.

Also, some refactoring (first of the two commits).