### PR TITLE
Append [skip-cd] to non-code commit messages

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "commit-msg": "bash ./scripts/commit-msg.sh"
     }
   },
   "lint-staged": {

--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -1,0 +1,8 @@
+set -e
+
+PUBLIC_STATIC=$(git diff --name-only --cached -- public/static)
+REPO=$(git diff --name-only --cached)
+
+if [ "$PUBLIC_STATIC" == "$REPO" ] && [ -n "$PUBLIC_STATIC" ]; then
+  echo "[skip-cd]" >> $HUSKY_GIT_PARAMS
+fi


### PR DESCRIPTION
This is for the planned CI/CD improvements.

Implements a Git hook that appends [skip-cd] to the commit message if a commit does not include code changes (i.e. modified files are only in `public/static/`). This will prevent the Amplify Console from trigger an unnecessary build.