### PR TITLE
Append [skip-cd] to merge commits

### DIFF
--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -2,7 +2,10 @@ set -e
 
 PUBLIC_STATIC=$(git diff --name-only --cached -- public/static)
 REPO=$(git diff --name-only --cached)
+COMMIT_MSG=$(cat $HUSKY_GIT_PARAMS)
 
-if [ "$PUBLIC_STATIC" == "$REPO" ] && [ -n "$PUBLIC_STATIC" ]; then
+if [[ $COMMIT_MSG == "Merge branch 'master' of"* ]]; then
+  echo "[skip-cd]" >> $HUSKY_GIT_PARAMS
+elif [ "$PUBLIC_STATIC" == "$REPO" ] && [ -n "$PUBLIC_STATIC" ]; then
   echo "[skip-cd]" >> $HUSKY_GIT_PARAMS
 fi


### PR DESCRIPTION
I realized that merge commits from the Communications Team will cause unnecessary builds.

@GeorgeBellTMH you are the only person directly pushes code to `master`, so your merge commits might need to trigger a build. Your options will be:
- avoid merge commits (rebase, stash then pull, pull before making changes, etc).
- change the merge commit message so the hook does not append [skip-cd]
- make PRs instead directly committing code

Edit: fourth option - trigger a build maually: https://docs.aws.amazon.com/amplify/latest/userguide/webhooks.html