### PR TITLE
Serve WebP images via <picture> tag

### DIFF
--- a/src/components/RenderRouter/BlogItem.tsx
+++ b/src/components/RenderRouter/BlogItem.tsx
@@ -177,9 +177,7 @@ class BlogItem extends React.Component<Props, State> {
   ): string {
     if (!title) return '';
     return (
-      `/static/photos/blogs/${style}/` +
-      encodeURIComponent(title.replace(/\?|[']/g, '')) +
-      '.jpg'
+      `/static/photos/blogs/${style}/` + title.replace(/\?|[']/g, '') + '.jpg'
     );
   }
 
@@ -221,16 +219,21 @@ class BlogItem extends React.Component<Props, State> {
                     to={'/posts/' + this.state.publishedOnly[0]?.id}
                     tabIndex={-1}
                   >
-                    <img
-                      alt="TBD"
+                    <ScaledImage
                       className="blog-image-desktop"
-                      src={this.getImageURI(
-                        this.state.publishedOnly[0]?.blogTitle,
-                        'baby-hero'
-                      )}
-                      onError={this.fallbackToImage(
-                        '/static/photos/blogs/baby-hero/fallback.jpg'
-                      )}
+                      breakpointSizes={{
+                        640: 640,
+                        1920: 960,
+                        2560: 1280,
+                      }}
+                      image={{
+                        src: this.getImageURI(
+                          this.state.publishedOnly[0]?.blogTitle,
+                          'baby-hero'
+                        ),
+                        alt:
+                          'blog post:' + this.state.publishedOnly[0]?.blogTitle,
+                      }}
                     />
                   </Link>
                 </div>
@@ -240,16 +243,21 @@ class BlogItem extends React.Component<Props, State> {
                   to={'/posts/' + this.state.publishedOnly[0]?.id}
                   tabIndex={-1}
                 >
-                  <img
-                    alt="TBD"
+                  <ScaledImage
                     className="blog-image-mobile"
-                    src={this.getImageURI(
-                      this.state.publishedOnly[0]?.blogTitle,
-                      'baby-hero'
-                    )}
-                    onError={this.fallbackToImage(
-                      '/static/photos/blogs/baby-hero/fallback.jpg'
-                    )}
+                    breakpointSizes={{
+                      320: 320,
+                      480: 480,
+                      640: 640,
+                    }}
+                    image={{
+                      src: this.getImageURI(
+                        this.state.publishedOnly[0]?.blogTitle,
+                        'baby-hero'
+                      ),
+                      alt:
+                        'blog post:' + this.state.publishedOnly[0]?.blogTitle,
+                    }}
                   />
                 </Link>
               </div>

--- a/src/components/RenderRouter/ListItem.tsx
+++ b/src/components/RenderRouter/ListItem.tsx
@@ -511,19 +511,13 @@ class ListItem extends React.Component<Props, State> {
   ): string {
     if (!title) return '';
     return (
-      `/static/photos/blogs/${style}/` +
-      encodeURIComponent(title.replace(/\?|[']/g, '')) +
-      '.jpg'
+      `/static/photos/blogs/${style}/` + title.replace(/\?|[']/g, '') + '.jpg'
     );
   }
 
   getPlaylistImageURI(title: string | null): string {
     if (!title) return '';
-    return (
-      `/static/photos/playlists/` +
-      encodeURIComponent(title.replace(/\?|[']/g, '')) +
-      '.jpg'
-    );
+    return `/static/photos/playlists/` + title.replace(/\?|[']/g, '') + '.jpg';
   }
 
   renderBlogs(item: BlogData): JSX.Element | null {

--- a/src/components/ScaledImage/ScaledImage.tsx
+++ b/src/components/ScaledImage/ScaledImage.tsx
@@ -3,6 +3,7 @@ import {
   EventHandler,
   ReactElement,
   ImgHTMLAttributes,
+  useState,
 } from 'react';
 import { ItemImage } from 'components/types';
 
@@ -21,7 +22,15 @@ export function tmhImageUrl(size: number, imageSrc: string) {
   } else {
     baseUrl = 'https://www.themeetinghouse.com/cache/' + size;
   }
-  return `${baseUrl}${imageSrc} ${size}w`;
+  return `${baseUrl}${encodeURI(imageSrc)} ${size}w`;
+}
+
+function tmhWebpUrl(size: number, imageSrc: string) {
+  const fileExt = imageSrc.substring(imageSrc.lastIndexOf('.'));
+
+  return `https://www.themeetinghouse.com/cache/${size}webp${encodeURI(
+    imageSrc.replace(fileExt, '.webp')
+  )} ${size}w`;
 }
 
 export function fallbackToImage(
@@ -39,6 +48,8 @@ export function fallbackToImage(
 }
 
 export default function ScaledImage(props: Props): ReactElement<Props> | null {
+  const [isError, setIsError] = useState(false);
+
   const {
     image,
     fallbackUrl,
@@ -71,6 +82,10 @@ export default function ScaledImage(props: Props): ReactElement<Props> | null {
     .map(([, size]) => tmhImageUrl(size, image.src))
     .join(',');
 
+  const webpSrcSet = imageSizes
+    .map(([, size]) => tmhWebpUrl(size, image.src))
+    .join(',');
+
   let sizesAttr = imageSizes
     .slice(0, imageSizes.length - 2)
     .map(([breakpoint, size]) => `(max-width: ${breakpoint}px) ${size}px`)
@@ -80,13 +95,19 @@ export default function ScaledImage(props: Props): ReactElement<Props> | null {
 
   const uri = tmhImageUrl(largestSize, image.src);
   return (
-    <img
-      src={uri.substring(0, uri.lastIndexOf(' ') + 1)}
-      alt={image.alt}
-      onError={fallbackToImage(fallbackUrl)}
-      srcSet={srcSet}
-      sizes={sizesAttr}
-      {...htmlProps}
-    />
+    <picture>
+      {!isError && (
+        <>
+          <source srcSet={webpSrcSet} sizes={sizesAttr} type="image/webp" />
+          <source srcSet={srcSet} sizes={sizesAttr} type="image/jpeg" />
+        </>
+      )}
+      <img
+        src={isError ? fallbackUrl : uri.substring(0, uri.lastIndexOf(' ') + 1)}
+        alt={image.alt}
+        onError={() => setIsError(true)}
+        {...htmlProps}
+      />
+    </picture>
   );
 }

--- a/src/components/ScaledImage/ScaledImage.tsx
+++ b/src/components/ScaledImage/ScaledImage.tsx
@@ -13,6 +13,10 @@ interface Props extends ImgHTMLAttributes<HTMLImageElement> {
   breakpointSizes: { [maxWidth: string]: number };
 }
 
+function encodeImageURI(s: string) {
+  return encodeURIComponent(s).replace(/%2F/g, '/');
+}
+
 export function tmhImageUrl(size: number, imageSrc: string) {
   let baseUrl: string;
   if (window.location.hostname === 'localhost') {
@@ -22,13 +26,13 @@ export function tmhImageUrl(size: number, imageSrc: string) {
   } else {
     baseUrl = 'https://www.themeetinghouse.com/cache/' + size;
   }
-  return `${baseUrl}${encodeURI(imageSrc)} ${size}w`;
+  return `${baseUrl}${encodeImageURI(imageSrc)} ${size}w`;
 }
 
 function tmhWebpUrl(size: number, imageSrc: string) {
   const fileExt = imageSrc.substring(imageSrc.lastIndexOf('.'));
 
-  return `https://www.themeetinghouse.com/cache/${size}webp${encodeURI(
+  return `https://www.themeetinghouse.com/cache/${size}webp${encodeImageURI(
     imageSrc.replace(fileExt, '.webp')
   )} ${size}w`;
 }


### PR DESCRIPTION
Closes #561. Related to #690.

Chrome, Firefox, Edge (and most other modern browsers) are successfully rendering WebP. Safari will select the JPG srcset (until WebP is fully supported). 

https://caniuse.com/?search=webp

There appears to be a cold start issue with the WebP images, but after a few requests, the images load without issue.