### PR TITLE
Fix add to calendar component + add button on Easter page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@aws-amplify/api": "^3.2.20",
         "@aws-amplify/ui-react": "^1.0.1",
-        "@esetnik/react-add-to-calendar": "^0.1.8",
         "@sentry/browser": "^6.1.0",
         "aws-amplify": "^3.3.19",
         "bootstrap": "^4.5.3",
@@ -1849,9 +1848,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -4207,22 +4203,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
-    "node_modules/@esetnik/react-add-to-calendar": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@esetnik/react-add-to-calendar/-/react-add-to-calendar-0.1.9.tgz",
-      "integrity": "sha512-CtrAyFVP8vjxSKERQ+XtlcX6JyRlaeZqCVooInYl2EecQClnCUbYRGCTa3zt+FZyR0VxL/bYo1IO1JxBS1Xiaw==",
-      "dependencies": {
-        "moment": "^2.18.1",
-        "node-sass": "^5.0.0"
-      },
-      "optionalDependencies": {
-        "moment": "^2.18.1"
-      },
-      "peerDependencies": {
-        "react": "^15.5.4 || ^16.0.0 || ^17.0.0",
-        "react-dom": "^15.5.4 || ^16.0.0 || ^17.0.0"
-      }
-    },
     "node_modules/@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -4434,7 +4414,6 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
-        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -4779,9 +4758,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6250,7 +6226,9 @@
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -6414,6 +6392,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.4.2"
       }
@@ -6652,6 +6632,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -6716,6 +6698,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6929,6 +6913,8 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
       "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8220,6 +8206,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
@@ -8232,6 +8220,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
       "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8317,7 +8307,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -8643,6 +8632,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8894,7 +8885,9 @@
     "node_modules/console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/constants-browserify": {
       "version": "1.0.0",
@@ -9535,6 +9528,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "array-find-index": "^1.0.1"
       },
@@ -9907,7 +9902,9 @@
     "node_modules/delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/denodeify": {
       "version": "1.2.1",
@@ -10408,6 +10405,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
       "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -10565,8 +10564,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -12635,6 +12633,8 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -12650,6 +12650,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12658,6 +12660,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -12669,6 +12673,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -12682,6 +12688,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12693,6 +12701,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "globule": "^1.0.0"
       },
@@ -12882,6 +12892,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
@@ -12985,6 +12997,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -12996,6 +13010,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13022,7 +13038,9 @@
     "node_modules/has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/has-value": {
       "version": "1.0.0",
@@ -14263,6 +14281,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       },
@@ -14471,7 +14491,9 @@
     "node_modules/is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-windows": {
       "version": "1.0.2",
@@ -15071,7 +15093,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -15448,7 +15469,9 @@
     "node_modules/js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/js-cookie": {
       "version": "2.2.1",
@@ -15601,7 +15624,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
       "dependencies": {
-        "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       },
       "optionalDependencies": {
@@ -15687,9 +15709,6 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.9"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.9"
       }
@@ -16050,6 +16069,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -16147,6 +16168,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16203,6 +16226,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -16223,6 +16248,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "path-exists": "^2.0.0",
         "pinkie-promise": "^2.0.0"
@@ -16235,6 +16262,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^2.2.0",
@@ -16250,6 +16279,8 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "error-ex": "^1.2.0"
       },
@@ -16261,6 +16292,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "pinkie-promise": "^2.0.0"
       },
@@ -16272,6 +16305,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "pify": "^2.0.0",
@@ -16285,6 +16320,8 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -16293,6 +16330,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "load-json-file": "^1.0.0",
         "normalize-package-data": "^2.3.2",
@@ -16306,6 +16345,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "find-up": "^1.0.0",
         "read-pkg": "^1.0.0"
@@ -16318,6 +16359,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-utf8": "^0.2.0"
       },
@@ -16973,7 +17016,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -17942,7 +17984,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -18067,9 +18108,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "peer": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -18747,7 +18785,8 @@
     "node_modules/nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "node_modules/nanoid": {
       "version": "3.1.20",
@@ -18880,6 +18919,8 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
       "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -18971,6 +19012,8 @@
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
       "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -19000,6 +19043,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19008,6 +19053,8 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19016,6 +19063,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
@@ -19031,6 +19080,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19039,6 +19090,8 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -19050,6 +19103,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -19067,6 +19122,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "abbrev": "1"
       },
@@ -19141,6 +19198,8 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -19171,6 +19230,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -22591,7 +22652,6 @@
         "eslint-webpack-plugin": "^2.1.0",
         "file-loader": "6.1.1",
         "fs-extra": "^9.0.1",
-        "fsevents": "^2.1.3",
         "html-webpack-plugin": "4.5.0",
         "identity-obj-proxy": "3.0.0",
         "jest": "26.6.0",
@@ -23001,6 +23061,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -23013,6 +23075,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "repeating": "^2.0.0"
       },
@@ -23196,6 +23260,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-finite": "^1.0.0"
       },
@@ -24072,6 +24138,8 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
@@ -24086,6 +24154,8 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
       "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -24094,6 +24164,8 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -24105,6 +24177,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^3.1.0",
         "strip-ansi": "^5.2.0",
@@ -24115,6 +24189,8 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -24122,17 +24198,23 @@
     "node_modules/sass-graph/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sass-graph/node_modules/emoji-regex": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sass-graph/node_modules/find-up": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
       "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "locate-path": "^3.0.0"
       },
@@ -24144,6 +24226,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24152,6 +24236,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
       "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
@@ -24164,6 +24250,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
       "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-limit": "^2.0.0"
       },
@@ -24175,6 +24263,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -24183,6 +24273,8 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
       "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
@@ -24196,6 +24288,8 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
       "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^4.1.0"
       },
@@ -24207,6 +24301,8 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-styles": "^3.2.0",
         "string-width": "^3.0.0",
@@ -24220,6 +24316,8 @@
       "version": "13.3.2",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "cliui": "^5.0.0",
         "find-up": "^3.0.0",
@@ -24237,6 +24335,8 @@
       "version": "13.1.2",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
@@ -24288,6 +24388,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "js-base64": "^2.1.8",
         "source-map": "^0.4.2"
@@ -24297,6 +24399,8 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "amdefine": ">=0.0.4"
       },
@@ -25316,6 +25420,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.0.1"
       }
@@ -25537,6 +25643,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "get-stdin": "^4.0.1"
       },
@@ -25551,6 +25659,8 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26218,6 +26328,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26226,6 +26338,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.2"
       }
@@ -26975,10 +27089,8 @@
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.5.tgz",
       "integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
       "dependencies": {
-        "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.1"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "chokidar": "^3.4.1",
@@ -27068,7 +27180,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -27488,7 +27599,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -28015,9 +28125,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -28396,6 +28503,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
@@ -28404,6 +28513,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
       "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -28412,6 +28523,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -28420,6 +28533,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
@@ -28432,6 +28547,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
       },
@@ -28532,9 +28649,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -30637,7 +30751,8 @@
           }
         },
         "react": {
-          "version": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
           "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
           "peer": true,
           "requires": {
@@ -30647,7 +30762,8 @@
           }
         },
         "react-native": {
-          "version": "https://registry.npmjs.org/react-native/-/react-native-0.63.4.tgz",
+          "version": "0.63.4",
+          "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.63.4.tgz",
           "integrity": "sha512-I4kM8kYO2mWEYUFITMcpRulcy4/jd+j9T6PbIzR0FuMcz/xwd+JwHoLPa1HmCesvR1RDOw9o4D+OFLwuXXfmGw==",
           "peer": true,
           "requires": {
@@ -32472,15 +32588,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
-    "@esetnik/react-add-to-calendar": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/@esetnik/react-add-to-calendar/-/react-add-to-calendar-0.1.9.tgz",
-      "integrity": "sha512-CtrAyFVP8vjxSKERQ+XtlcX6JyRlaeZqCVooInYl2EecQClnCUbYRGCTa3zt+FZyR0VxL/bYo1IO1JxBS1Xiaw==",
-      "requires": {
-        "moment": "^2.18.1",
-        "node-sass": "^5.0.0"
-      }
-    },
     "@eslint/eslintrc": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
@@ -34118,7 +34225,9 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "optional": true,
+      "peer": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -34161,7 +34270,8 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -34214,12 +34324,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -34241,7 +34353,9 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "optional": true,
+      "peer": true
     },
     "anser": {
       "version": "1.4.10",
@@ -34418,6 +34532,8 @@
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -34469,7 +34585,9 @@
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
-      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
+      "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E=",
+      "optional": true,
+      "peer": true
     },
     "array-flatten": {
       "version": "2.1.2",
@@ -34641,7 +34759,9 @@
     "async-foreach": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz",
-      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI="
+      "integrity": "sha1-NhIfhFwFeBct5Bmpfb6x0W7DRUI=",
+      "optional": true,
+      "peer": true
     },
     "async-limiter": {
       "version": "1.0.1",
@@ -34881,7 +35001,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
-      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
+      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
+      "requires": {}
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
@@ -35355,7 +35476,8 @@
     "bootstrap": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.6.0.tgz",
-      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw=="
+      "integrity": "sha512-Io55IuQY3kydzHtbGvQya3H+KorS/M9rSNyfCGCg9WZ4pyT/lCxIlpJgG1GXW/PswzC84Tr2fBYi+7+jFVQQBw==",
+      "requires": {}
     },
     "bowser": {
       "version": "2.11.0",
@@ -35700,6 +35822,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "camelcase": "^2.0.0",
         "map-obj": "^1.0.0"
@@ -35708,7 +35832,9 @@
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -36031,7 +36157,9 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "optional": true,
+      "peer": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -36253,7 +36381,9 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true,
+      "peer": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -36756,6 +36886,8 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "array-find-index": "^1.0.1"
       }
@@ -37038,7 +37170,9 @@
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true,
+      "peer": true
     },
     "denodeify": {
       "version": "1.2.1",
@@ -37313,7 +37447,8 @@
     "draftjs-utils": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/draftjs-utils/-/draftjs-utils-0.10.2.tgz",
-      "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg=="
+      "integrity": "sha512-EstHqr3R3JVcilJrBaO/A+01GvwwKmC7e4TCjC7S94ZeMh4IVmf60OuQXtHHpwItK8C2JCi3iljgN5KHkJboUg==",
+      "requires": {}
     },
     "duplexer": {
       "version": "0.1.2",
@@ -37465,7 +37600,9 @@
     "env-paths": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
-      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+      "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==",
+      "optional": true,
+      "peer": true
     },
     "envinfo": {
       "version": "7.7.4",
@@ -37689,7 +37826,8 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-7.2.0.tgz",
       "integrity": "sha512-rV4Qu0C3nfJKPOAhFujFxB7RMP+URFyQqqOZW9DMRD7ZDTFyjaIlETU3xzHELt++4ugC0+Jm084HQYkkJe+Ivg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-config-react-app": {
       "version": "6.0.0",
@@ -37983,7 +38121,8 @@
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.1",
@@ -39166,6 +39305,8 @@
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -39180,12 +39321,16 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true,
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -39194,6 +39339,8 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -39204,6 +39351,8 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -39214,6 +39363,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "globule": "^1.0.0"
       }
@@ -39350,6 +39501,8 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.3.2.tgz",
       "integrity": "sha512-7IDTQTIu2xzXkT+6mlluidnWo+BypnbSoEVVQCGfzqnl5Ik8d3e1d4wycb8Rj9tWW+Z39uPWsdlquqiqPCd/pA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
@@ -39359,7 +39512,8 @@
     "google-maps-react": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/google-maps-react/-/google-maps-react-2.0.6.tgz",
-      "integrity": "sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ=="
+      "integrity": "sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ==",
+      "requires": {}
     },
     "graceful-fs": {
       "version": "4.2.5",
@@ -39430,6 +39584,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -39437,7 +39593,9 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -39454,7 +39612,9 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true,
+      "peer": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -39681,7 +39841,8 @@
     "html-to-draftjs": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/html-to-draftjs/-/html-to-draftjs-1.5.0.tgz",
-      "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ=="
+      "integrity": "sha512-kggLXBNciKDwKf+KYsuE+V5gw4dZ7nHyGMX9m0wy7urzWjKGWyNFetmArRLvRV0VrxKN70WylFsJvMTJx02OBQ==",
+      "requires": {}
     },
     "html-webpack-plugin": {
       "version": "4.5.0",
@@ -40408,7 +40569,9 @@
     "is-finite": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w=="
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "optional": true,
+      "peer": true
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -40545,7 +40708,9 @@
     "is-utf8": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
-      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
+      "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+      "optional": true,
+      "peer": true
     },
     "is-windows": {
       "version": "1.0.2",
@@ -41115,7 +41280,8 @@
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "26.0.0",
@@ -41325,7 +41491,9 @@
     "js-base64": {
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
-      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ=="
+      "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "optional": true,
+      "peer": true
     },
     "js-cookie": {
       "version": "2.2.1",
@@ -41813,6 +41981,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "currently-unhandled": "^0.4.1",
         "signal-exit": "^3.0.0"
@@ -41892,7 +42062,9 @@
     "map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
+      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "optional": true,
+      "peer": true
     },
     "map-visit": {
       "version": "1.0.0",
@@ -41940,6 +42112,8 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "camelcase-keys": "^2.0.0",
         "decamelize": "^1.1.2",
@@ -41957,6 +42131,8 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "path-exists": "^2.0.0",
             "pinkie-promise": "^2.0.0"
@@ -41966,6 +42142,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "parse-json": "^2.2.0",
@@ -41978,6 +42156,8 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "error-ex": "^1.2.0"
           }
@@ -41986,6 +42166,8 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "pinkie-promise": "^2.0.0"
           }
@@ -41994,6 +42176,8 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "graceful-fs": "^4.1.2",
             "pify": "^2.0.0",
@@ -42003,12 +42187,16 @@
         "pify": {
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "optional": true,
+          "peer": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "load-json-file": "^1.0.0",
             "normalize-package-data": "^2.3.2",
@@ -42019,6 +42207,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "find-up": "^1.0.0",
             "read-pkg": "^1.0.0"
@@ -42028,6 +42218,8 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "is-utf8": "^0.2.0"
           }
@@ -44049,7 +44241,8 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
     },
     "nanoid": {
       "version": "3.1.20",
@@ -44165,6 +44358,8 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-7.1.2.tgz",
       "integrity": "sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "env-paths": "^2.2.0",
         "glob": "^7.1.4",
@@ -44248,6 +44443,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-5.0.0.tgz",
       "integrity": "sha512-opNgmlu83ZCF792U281Ry7tak9IbVC+AKnXGovcQ8LG8wFaJv6cLnRlc6DIHlmNxWEexB5bZxi9SZ9JyUuOYjw==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "async-foreach": "^0.1.3",
         "chalk": "^1.1.1",
@@ -44270,17 +44467,23 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true,
+          "peer": true
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "optional": true,
+          "peer": true
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -44292,12 +44495,16 @@
         "get-stdin": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true,
+          "peer": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -44305,7 +44512,9 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -44319,6 +44528,8 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-5.0.0.tgz",
       "integrity": "sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "abbrev": "1"
       }
@@ -44374,6 +44585,8 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -44403,7 +44616,9 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "optional": true,
+      "peer": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -46964,12 +47179,14 @@
     "react-ga": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
-      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==",
+      "requires": {}
     },
     "react-hamburger-menu": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/react-hamburger-menu/-/react-hamburger-menu-1.2.1.tgz",
-      "integrity": "sha512-It5Jque8bx9lYn8q/NFtu9Ci20fBMsyunFSp06ZGgWXbMZlTFrN0IxKguGZ0igYQr6RvJ3S9CN3rTjrObmq/Cw=="
+      "integrity": "sha512-It5Jque8bx9lYn8q/NFtu9Ci20fBMsyunFSp06ZGgWXbMZlTFrN0IxKguGZ0igYQr6RvJ3S9CN3rTjrObmq/Cw==",
+      "requires": {}
     },
     "react-helmet": {
       "version": "6.1.0",
@@ -47019,12 +47236,14 @@
     "react-minimal-pie-chart": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/react-minimal-pie-chart/-/react-minimal-pie-chart-8.1.0.tgz",
-      "integrity": "sha512-eoorRrGySbkkzpG1vX0/p18xxhSA/6OqIlMnlAlMez+cjfLnsX/u8+PFaOsWltQwhiwtA4DaO8VriWKryIluyg=="
+      "integrity": "sha512-eoorRrGySbkkzpG1vX0/p18xxhSA/6OqIlMnlAlMez+cjfLnsX/u8+PFaOsWltQwhiwtA4DaO8VriWKryIluyg==",
+      "requires": {}
     },
     "react-onclickoutside": {
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.10.0.tgz",
-      "integrity": "sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ=="
+      "integrity": "sha512-7i2L3ef+0ILXpL6P+Hg304eCQswh4jl3ynwR71BSlMU49PE2uk31k8B2GkP6yE9s2D4jTGKnzuSpzWxu4YxfQQ==",
+      "requires": {}
     },
     "react-popper": {
       "version": "1.3.7",
@@ -47272,7 +47491,8 @@
     "react-side-effect": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.1.tgz",
-      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ=="
+      "integrity": "sha512-2FoTQzRNTncBVtnzxFOk2mCpcfxQpenBMbk5kSVBg5UcPqV9fRbgY2zhb7GTWWOlpFmAxhClBDlIq8Rsubz1yQ==",
+      "requires": {}
     },
     "react-transition-group": {
       "version": "4.3.0",
@@ -47393,6 +47613,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "indent-string": "^2.1.0",
         "strip-indent": "^1.0.1"
@@ -47402,6 +47624,8 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
           "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "repeating": "^2.0.0"
           }
@@ -47546,6 +47770,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "is-finite": "^1.0.0"
       }
@@ -48234,6 +48460,8 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/sass-graph/-/sass-graph-2.2.5.tgz",
       "integrity": "sha512-VFWDAHOe6mRuT4mZRd4eKE+d8Uedrk6Xnh7Sh9b4NGufQLQjOrvf/MQoOdx+0s92L89FeyUUNfU597j/3uNpag==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "glob": "^7.0.0",
         "lodash": "^4.0.0",
@@ -48244,12 +48472,16 @@
         "ansi-regex": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "optional": true,
+          "peer": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -48258,6 +48490,8 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
           "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -48268,6 +48502,8 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -48275,17 +48511,23 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "optional": true,
+          "peer": true
         },
         "emoji-regex": {
           "version": "7.0.3",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+          "optional": true,
+          "peer": true
         },
         "find-up": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "locate-path": "^3.0.0"
           }
@@ -48293,12 +48535,16 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true,
+          "peer": true
         },
         "locate-path": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
@@ -48308,6 +48554,8 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "p-limit": "^2.0.0"
           }
@@ -48315,12 +48563,16 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "optional": true,
+          "peer": true
         },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -48331,6 +48583,8 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^4.1.0"
           }
@@ -48339,6 +48593,8 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
           "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -48349,6 +48605,8 @@
           "version": "13.3.2",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
           "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "cliui": "^5.0.0",
             "find-up": "^3.0.0",
@@ -48366,6 +48624,8 @@
           "version": "13.1.2",
           "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
           "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -48409,6 +48669,8 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "js-base64": "^2.1.8",
         "source-map": "^0.4.2"
@@ -48418,6 +48680,8 @@
           "version": "0.4.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "amdefine": ">=0.0.4"
           }
@@ -49278,6 +49542,8 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/stdout-stream/-/stdout-stream-1.4.1.tgz",
       "integrity": "sha512-j4emi03KXqJWcIeF8eIXkjMFN1Cmb8gUlDYGeBALLPo5qdyTfA9bOtl8m33lRoC+vFMkP3gl0WsDr6+gzxbbTA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "readable-stream": "^2.0.1"
       }
@@ -49456,6 +49722,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+      "optional": true,
+      "peer": true,
       "requires": {
         "get-stdin": "^4.0.1"
       },
@@ -49463,7 +49731,9 @@
         "get-stdin": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
+          "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -49971,12 +50241,16 @@
     "trim-newlines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
-      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
+      "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM=",
+      "optional": true,
+      "peer": true
     },
     "true-case-path": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-1.0.3.tgz",
       "integrity": "sha512-m6s2OdQe5wgpFMC+pAJ+q9djG82O2jcHPOI6RNg1yy9rCYR+WD6Nbpl32fDpfC56nirdRy+opFa/Vk7HYhqaew==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "glob": "^7.1.2"
       }
@@ -50383,7 +50657,8 @@
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.1.tgz",
-      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ=="
+      "integrity": "sha512-L7Evj8FGcwo/wpbv/qvSfrkHFtOpCzvM5yl2KVyDJoylVuSvzphiiasmjgQPttIGBAy2WKiBNR98q8w7PiNgKQ==",
+      "requires": {}
     },
     "use-latest": {
       "version": "1.2.0",
@@ -51691,6 +51966,8 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "optional": true,
+      "peer": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       },
@@ -51698,17 +51975,23 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "optional": true,
+          "peer": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "optional": true,
+          "peer": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -51718,6 +52001,8 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "optional": true,
+          "peer": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -51978,7 +52263,8 @@
     "ws": {
       "version": "7.4.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
-      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA=="
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
+      "requires": {}
     },
     "xcode": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
   "dependencies": {
     "@aws-amplify/api": "^3.2.20",
     "@aws-amplify/ui-react": "^1.0.1",
-    "@esetnik/react-add-to-calendar": "^0.1.8",
     "@sentry/browser": "^6.1.0",
     "aws-amplify": "^3.3.19",
     "bootstrap": "^4.5.3",

--- a/public/static/content/easter.json
+++ b/public/static/content/easter.json
@@ -45,7 +45,14 @@
             "src": "/static/images/easter-6.jpg",
             "alt": "Person on the couch is watching The Meeting House Easter livestream teaching on their laptop."
           }
-        ]
+        ],
+        "calendar": {
+          "start": "2021-04-04T10:00:00-04:00",
+          "end": "2021-04-04T11:30:00-04:00",
+          "summary": "Easter Sunday",
+          "description": "Join The Meeting House's livestream on Easter Sunday.",
+          "url": "https://www.themeetinghouse.com/live"
+        }
       },
       {
         "type": "hero",

--- a/scripts/json-lint.py
+++ b/scripts/json-lint.py
@@ -125,6 +125,13 @@ for json_file in glob.glob(cwd + path):
                                 assert(isinstance(item[i]['text'], str))
                             elif i == 'images':
                                 assert_image(item[i], check_link_to=True)
+                            elif i == 'calendar':
+                                assert(item['style'] in ['oneImage', 'oneImageBlack', 'oneImageBlackRight'])
+                                assert(isinstance(item[i], dict))
+                                for j in ['start', 'end', 'summary', 'description']:
+                                    assert(isinstance(item[i][j], str))
+                                for j in ['url', 'location']:
+                                    assert(j not in item[i] or isinstance(item[i][j], str))
 
                     elif item_type == 'list':
                         assert(isinstance(item, dict))

--- a/src/components/AddToCalendar/AddToCalendar.scss
+++ b/src/components/AddToCalendar/AddToCalendar.scss
@@ -1,0 +1,16 @@
+@use '../../theme.scss';
+
+.add-to-calendar {
+  font-family: Graphik Web;
+  font-size: 1vw;
+  background: transparent;
+  border: none;
+  &.white {
+    color: #ffffff;
+  }
+  &.black {
+    color: theme.$onyxblacktext;
+  }
+  text-decoration: underline;
+  text-underline-offset: 0.25em;
+}

--- a/src/components/AddToCalendar/AddToCalendar.scss
+++ b/src/components/AddToCalendar/AddToCalendar.scss
@@ -1,16 +1,58 @@
 @use '../../theme.scss';
 
-.add-to-calendar {
-  font-family: Graphik Web;
-  font-size: 1vw;
-  background: transparent;
-  border: none;
-  &.white {
-    color: #ffffff;
+.add-to-calendar-wrapper {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+
+  .add-to-calendar {
+    font-family: Graphik Web;
+    font-size: 16px;
+    background: transparent;
+    border: none;
+    padding-left: 0;
+    padding-right: 0;
+    &.white {
+      color: #ffffff;
+    }
+    &.black {
+      color: theme.$onyxblacktext;
+    }
+    &.decoration {
+      text-decoration: underline;
+    }
+    &.hover-decoration {
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+    text-underline-offset: 0.25em;
   }
-  &.black {
-    color: theme.$onyxblacktext;
+
+  a {
+    &::before {
+      width: 15px;
+      height: 15px;
+      content: '';
+      vertical-align: middle;
+      background-size: contain;
+      background-position-y: center;
+      background-repeat: no-repeat;
+      display: inline-block;
+      margin: 5px 5px 8px 0;
+    }
+
+    &.Apple::before {
+      background-image: url('../../svg/Apple.svg');
+    }
+
+    &.Outlook::before,
+    &.Outlookcom::before {
+      background-image: url('../../svg/Outlook.svg');
+    }
+
+    &.Google::before {
+      background-image: url('../../svg/Google.svg');
+    }
   }
-  text-decoration: underline;
-  text-underline-offset: 0.25em;
 }

--- a/src/components/AddToCalendar/AddToCalendar.tsx
+++ b/src/components/AddToCalendar/AddToCalendar.tsx
@@ -9,12 +9,12 @@ import {
 } from 'reactstrap';
 import { useState } from 'react';
 
-type Event = {
+export type Event = {
   start: string;
   end: string;
   summary: string;
   description: string;
-  location: string;
+  location?: string;
   url?: string;
 };
 
@@ -23,6 +23,7 @@ interface Props {
   color: 'white' | 'black';
   textDecoration?: 'always' | 'hover';
   style?: React.CSSProperties;
+  className?: string;
 }
 
 function formatDateTime(date: string) {
@@ -40,6 +41,8 @@ function formatDateTime(date: string) {
  * @return Formatted calendar URL or iCal file.
  */
 function calendarUrl(event: Event, provider?: string) {
+  const body = (event.url ? event.url + '\n\n' : '') + event.description;
+
   switch (provider) {
     case 'Google':
       return (
@@ -49,12 +52,13 @@ function calendarUrl(event: Event, provider?: string) {
         formatDateTime(event.start) +
         '/' +
         formatDateTime(event.end) +
-        '&location=' +
-        encodeURIComponent(event.location) +
+        (event.location
+          ? '&location=' + encodeURIComponent(event.location)
+          : '') +
         '&text=' +
         encodeURIComponent(event.summary) +
         '&details=' +
-        encodeURIComponent(event.description + '\n\n' + event.url)
+        encodeURIComponent(body)
       );
 
     case 'Outlook.com':
@@ -66,10 +70,11 @@ function calendarUrl(event: Event, provider?: string) {
         formatDateTime(event.end) +
         '&subject=' +
         encodeURIComponent(event.summary) +
-        '&location=' +
-        encodeURIComponent(event.location) +
+        (event.location
+          ? '&location=' + encodeURIComponent(event.location)
+          : '') +
         '&body=' +
-        encodeURIComponent(event.description + '\n\n' + event.url) +
+        encodeURIComponent(body) +
         '&allday=false' +
         '&uid=' +
         uuidv4() +
@@ -88,7 +93,7 @@ function calendarUrl(event: Event, provider?: string) {
         `UID:${uuidv4()}\n` +
         `DTSTART:${formatDateTime(event.start)}\n` +
         `DTEND:${formatDateTime(event.start)}\n` +
-        `LOCATION:${event.location}\n` +
+        (event.location ? 'LOCATION:' + event.location + '\n' : '') +
         (event.url ? 'URL:' + event.url + '\n' : '') +
         'END:VEVENT\n' +
         'END:VCALENDAR'
@@ -106,12 +111,14 @@ function calendarUrl(event: Event, provider?: string) {
  * Text decoration appears on hover when `"hover"`.
  * Text decoration is never visible when `undefined`.
  * @param style Optional inline styles for wrapping div.
+ * @param className Optional className for wrapping div.
  */
 export default function AddToCalendar({
   event,
   color,
   textDecoration,
   style,
+  className,
 }: Props) {
   const strokeColor = color === 'white' ? '#FFFFFF' : '#1A1A1A';
   const [open, setOpen] = useState(false);
@@ -120,7 +127,7 @@ export default function AddToCalendar({
   const platforms = ['Apple', 'Google', 'Outlook', 'Outlook.com'];
 
   return (
-    <div className="add-to-calendar-wrapper" style={style}>
+    <div className={'add-to-calendar-wrapper ' + className} style={style}>
       <svg
         style={{ marginRight: 10 }}
         width={25}

--- a/src/components/AddToCalendar/AddToCalendar.tsx
+++ b/src/components/AddToCalendar/AddToCalendar.tsx
@@ -1,0 +1,104 @@
+import { v4 as uuidv4 } from 'uuid';
+import './AddToCalendar.scss';
+
+interface Props {
+  event: {
+    start: string;
+    end: string;
+    summary: string;
+    description: string;
+    rRule?: string;
+    geo: string;
+    location: string;
+    url?: string;
+  };
+  color: 'white' | 'black';
+}
+
+export default function AddToCalendar({ event, color }: Props) {
+  const strokeColor = color === 'white' ? '#FFFFFF' : '#1A1A1A';
+  const ics =
+    'BEGIN:VCALENDAR\n' +
+    'VERSION:2.0\n' +
+    'PRODID:-//The Meeting House Church Family//TMH Cal 1.0//EN\n' +
+    'CALSCALE:GREGORIAN\n' +
+    'BEGIN:VEVENT\n' +
+    `SUMMARY:${event.summary}\n` +
+    `DESCRIPTION:${event.description}\n` +
+    `UID:${uuidv4()}\n` +
+    (event.rRule ? 'RRULE:' + event.rRule + '\n' : '') +
+    `DTSTART:${event.start}\n` +
+    `DTEND:${event.end}\n` +
+    `LOCATION:${event.location}\n` +
+    `GEO:${event.geo}\n` +
+    (event.url ? 'URL:' + event.url + '\n' : '') +
+    'END:VEVENT' +
+    'END:VCALENDAR';
+
+  if (ics) {
+    return (
+      <>
+        <svg
+          style={{ marginRight: 10 }}
+          width={25}
+          height={25}
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 17V23"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+            strokeLinecap="square"
+          />
+          <path
+            d="M17 20H23"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+            strokeLinecap="square"
+          />
+          <path
+            d="M12 22H1V4H23V12"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+            strokeLinecap="square"
+          />
+          <path
+            d="M7 1V4"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+            strokeLinecap="square"
+          />
+          <path
+            d="M17 1V4"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+            strokeLinecap="square"
+          />
+          <path
+            d="M1 8H23"
+            stroke={strokeColor}
+            strokeWidth="1.5"
+            strokeMiterlimit="10"
+          />
+        </svg>
+        <button
+          onClick={() =>
+            window.open('data:text/calendar;charset=utf8,' + escape(ics))
+          }
+          className={'add-to-calendar ' + color}
+        >
+          Add to Calendar
+        </button>
+      </>
+    );
+  }
+
+  return null;
+}

--- a/src/components/AddToCalendar/AddToCalendar.tsx
+++ b/src/components/AddToCalendar/AddToCalendar.tsx
@@ -37,7 +37,7 @@ function formatDateTime(date: string) {
  * Used under the MIT license: https://github.com/jasonsalzman/react-add-to-calendar/blob/master/LICENSE
  *
  * @param event Object containing event data.
- * @param  provider Calendar provider.
+ * @param provider Calendar provider.
  * @return Formatted calendar URL or iCal file.
  */
 function calendarUrl(event: Event, provider?: string) {

--- a/src/components/RenderRouter/ContentItem.scss
+++ b/src/components/RenderRouter/ContentItem.scss
@@ -565,6 +565,10 @@
 }
 
 @media (max-width: 767px) {
+  .one-image-calendar {
+    margin-top: 24px;
+  }
+
   .pie {
     position: relative;
     text-align: center;

--- a/src/components/RenderRouter/ContentItem.tsx
+++ b/src/components/RenderRouter/ContentItem.tsx
@@ -6,6 +6,7 @@ import { Link, LinkButton } from 'components/Link/Link';
 import { ItemImage } from '../types';
 import './ContentItem.scss';
 import DataLoader, { LocationData, LocationQuery } from './DataLoader';
+import AddToCalendar, { Event } from '../AddToCalendar/AddToCalendar';
 
 type ContentList = Array<
   | {
@@ -49,6 +50,7 @@ interface ContentType {
   class?: string;
   filterField?: string;
   filterValue?: string;
+  calendar?: Event;
 }
 
 interface Props extends RouteComponentProps {
@@ -143,6 +145,14 @@ function ContentItem({ content }: Props) {
               <h2 className="oneImageH2">{content.header2}</h2>
               <div className="oneImageText">{content.text1}</div>
               <div className="oneImageList">{renderList()}</div>
+              {content.calendar && (
+                <AddToCalendar
+                  className="one-image-calendar"
+                  event={content.calendar}
+                  color="black"
+                  textDecoration="always"
+                />
+              )}
             </div>
             <ScaledImage
               image={image1}
@@ -181,6 +191,14 @@ function ContentItem({ content }: Props) {
               <h2 className="oneImageH2 white">{content.header2}</h2>
               <div className="oneImageText white">{content.text1}</div>
               {renderList('black')}
+              {content.calendar && (
+                <AddToCalendar
+                  className="one-image-calendar"
+                  event={content.calendar}
+                  color="white"
+                  textDecoration="always"
+                />
+              )}
             </div>
             <ScaledImage
               image={image1}
@@ -200,6 +218,14 @@ function ContentItem({ content }: Props) {
               <h2 className="oneImageH2 white">{content.header2}</h2>
               <div className="oneImageText white">{content.text1}</div>
               {renderList('black')}
+              {content.calendar && (
+                <AddToCalendar
+                  className="one-image-calendar"
+                  event={content.calendar}
+                  color="white"
+                  textDecoration="always"
+                />
+              )}
             </div>
             <ScaledImage
               image={image1}

--- a/src/components/RenderRouter/HeroItem.scss
+++ b/src/components/RenderRouter/HeroItem.scss
@@ -12,6 +12,13 @@
   margin-top: 1vw;
 }
 
+.contactPastorLink {
+  margin-top: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .react-select-custom {
   &__menu-list {
     @media (min-width: 768px) and (max-width: 1500px) {
@@ -37,6 +44,16 @@ $no-footer-height: 38vw;
   padding-bottom: 0;
 }
 
+.calendarButton {
+  font-size: 16px;
+  padding: 0;
+}
+
+.calendarImage {
+  margin-right: 10px;
+  height: 25px;
+}
+
 @media (min-width: 768px) {
   .covidButton {
     position: absolute;
@@ -50,86 +67,6 @@ $no-footer-height: 38vw;
     border: 0 !important;
     padding-right: 12.5vw !important;
     color: theme.$onyxblacktext !important;
-  }
-  .HeroAddToCalendarButtonContainer {
-    position: relative;
-    display: inline-block;
-    padding: 0.375rem 1.25rem;
-    margin-top: 1vw;
-    margin-bottom: 0.5rem;
-    font-family: Graphik Web;
-    color: #ffffff;
-    .SundaMorningIcon {
-      position: absolute;
-      left: 0;
-      top: 0;
-      padding-right: 0;
-      padding-left: 1.25rem;
-      pointer-events: none;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-    .react-add-to-calendar__button {
-      font-family: Graphik Web;
-      color: #ffffff;
-      border-width: 0px;
-      border-radius: 0;
-      font-size: 1vw;
-      text-decoration: underline !important;
-      font-weight: normal;
-      padding-left: 35px;
-      cursor: pointer;
-    }
-    .react-add-to-calendar__dropdown {
-      position: absolute;
-      z-index: 100;
-      top: 48px;
-      background: white;
-
-      border: 1px solid theme.$onyxblacktext;
-      padding: 10px 20px 0 20px;
-      ul {
-        list-style-type: none;
-        padding: 0;
-        font-family: Graphik Web;
-        font-size: 1vw;
-        a {
-          color: theme.$onyxblacktext !important;
-          vertical-align: middle;
-        }
-        li {
-          position: relative;
-          vertical-align: middle;
-        }
-        a::before {
-          width: 15px;
-          height: 15px;
-          vertical-align: middle;
-          background-size: contain;
-          background-position-y: center;
-          background-repeat: no-repeat;
-          display: inline-block;
-          content: '';
-          margin: 5px 5px 8px 0;
-        }
-
-        a.apple-link::before {
-          background-image: url('../../svg/Apple.svg');
-        }
-        a.outlook-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.outlookcom-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.yahoo-link::before {
-          background-image: url('../../svg/Yahoo.svg');
-        }
-        a.google-link::before {
-          background-image: url('../../svg/Google.svg');
-        }
-      }
-    }
   }
 
   .partialConnect {
@@ -453,19 +390,12 @@ $no-footer-height: 38vw;
   }
   .calendarButton {
     font-family: Graphik Web !important;
-    font-size: 1vw !important;
-    padding-top: 1vw;
-    padding-left: 1.5vw;
     color: #ffffff;
     font-weight: normal;
     background-color: theme.$onyxblacktext !important;
     border-width: 0 !important;
     border-radius: 0;
     text-decoration: underline !important;
-  }
-  .calendarImage {
-    margin-right: 10px;
-    height: 25px;
   }
   .heroItemButton {
     margin-top: 1.5vw;
@@ -496,83 +426,6 @@ $no-footer-height: 38vw;
     z-index: 1000;
     left: 20vw;
     top: 20vh;
-  }
-  .HeroAddToCalendarButtonContainer {
-    position: relative;
-    display: inline-block;
-    padding: 0.75rem 1.25rem;
-    font-family: Graphik Web;
-    color: #ffffff;
-    .SundaMorningIcon {
-      position: absolute;
-      left: 0;
-      top: 0;
-      padding-right: 0;
-      padding-left: 1.25rem;
-      pointer-events: none;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-    .react-add-to-calendar__button {
-      font-family: Graphik Web;
-      color: #ffffff;
-      border-width: 0px;
-      border-radius: 0;
-      font-size: 1vw;
-      text-decoration: underline !important;
-      font-weight: normal;
-      padding-left: 35px;
-      cursor: pointer;
-    }
-    .react-add-to-calendar__dropdown {
-      position: absolute;
-      z-index: 100;
-      top: 48px;
-      background: white;
-      border: 1px solid theme.$onyxblacktext;
-      padding: 10px 20px 0 20px;
-      ul {
-        list-style-type: none;
-        padding: 0;
-        font-family: Graphik Web;
-        font-size: 1vw;
-        a {
-          color: theme.$onyxblacktext !important;
-          vertical-align: middle;
-        }
-        li {
-          position: relative;
-          vertical-align: middle;
-        }
-        a::before {
-          width: 15px;
-          height: 15px;
-          vertical-align: middle;
-          background-size: contain;
-          background-position-y: center;
-          background-repeat: no-repeat;
-          display: inline-block;
-          content: '';
-          margin: 5px 5px 8px 0;
-        }
-
-        a.apple-link::before {
-          background-image: url('../../svg/Apple.svg');
-        }
-        a.outlook-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.outlookcom-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.yahoo-link::before {
-          background-image: url('../../svg/Yahoo.svg');
-        }
-        a.google-link::before {
-          background-image: url('../../svg/Google.svg');
-        }
-      }
-    }
   }
 
   .partialConnect {
@@ -898,17 +751,12 @@ $no-footer-height: 38vw;
   }
   .calendarButton {
     font-family: Graphik Web !important;
-    font-size: 1vw !important;
     margin-top: 1vw;
     color: #ffffff;
     background-color: theme.$onyxblacktext !important;
     border-width: 0 !important;
     border-radius: 0;
     text-decoration: underline !important;
-  }
-
-  .calendarImage {
-    margin-right: 5px;
   }
   .heroItemButton {
     margin-top: 1.5vw;
@@ -926,10 +774,16 @@ $no-footer-height: 38vw;
   }
 }
 
-@media (max-width: 357px) {
-  .calendarButton {
-    margin-top: 5vw !important;
-    padding-left: 0;
+@media (max-width: 1050px) {
+  .contactPastorLink {
+    margin-top: 16px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .contactPastor {
+    margin-top: 8px;
   }
 }
 
@@ -951,84 +805,6 @@ $no-footer-height: 38vw;
     left: 15vw;
     top: 40vh;
   }
-  .HeroAddToCalendarButtonContainer {
-    position: relative;
-    display: inline-block;
-    padding: 0.75rem 1.25rem;
-    font-family: Graphik Web;
-    color: #ffffff;
-    .SundaMorningIcon {
-      position: absolute;
-      left: 0;
-      top: 0;
-      padding-right: 0;
-      padding-left: 1.25rem;
-      pointer-events: none;
-      top: 50%;
-      transform: translateY(-50%);
-    }
-    .react-add-to-calendar__button {
-      font-family: Graphik Web;
-      color: #ffffff;
-      border-width: 0px;
-      border-radius: 0;
-      font-size: 3.5vw;
-      text-decoration: underline !important;
-      font-weight: normal;
-      padding-left: 35px;
-      cursor: pointer;
-    }
-    .react-add-to-calendar__dropdown {
-      position: absolute;
-      z-index: 100;
-      top: 48px;
-      background: white;
-      border: 1px solid theme.$onyxblacktext;
-      padding: 10px 20px 0 20px;
-      ul {
-        list-style-type: none;
-        padding: 0;
-        font-family: Graphik Web;
-        font-size: 1vw;
-        a {
-          color: theme.$onyxblacktext !important;
-          vertical-align: middle;
-        }
-        li {
-          position: relative;
-          vertical-align: middle;
-        }
-        a::before {
-          width: 15px;
-          height: 15px;
-          vertical-align: middle;
-          background-size: contain;
-          background-position-y: center;
-          background-repeat: no-repeat;
-          display: inline-block;
-          content: '';
-          margin: 5px 5px 8px 0;
-        }
-
-        a.apple-link::before {
-          background-image: url('../../svg/Apple.svg');
-        }
-        a.outlook-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.outlookcom-link::before {
-          background-image: url('../../svg/Outlook.svg');
-        }
-        a.yahoo-link::before {
-          background-image: url('../../svg/Yahoo.svg');
-        }
-        a.google-link::before {
-          background-image: url('../../svg/Google.svg');
-        }
-      }
-    }
-  }
-
   .partialConnect {
     position: relative;
     width: 100vw;
@@ -1316,18 +1092,12 @@ $no-footer-height: 38vw;
 
   .calendarButton {
     font-family: Graphik Web !important;
-    font-size: 3.5vw !important;
     font-weight: normal;
-    margin-top: 15vw;
     color: #ffffff;
     background-color: theme.$onyxblacktext !important;
     border-width: 0 !important;
     border-radius: 0;
     text-decoration: underline !important;
-  }
-  .calendarImage {
-    margin-right: 5px;
-    padding-left: 0.5rem;
   }
   .heroItemButton {
     margin-top: 1.5vw;
@@ -1353,11 +1123,5 @@ $no-footer-height: 38vw;
 
   .heroAContainer {
     margin-top: 5vw;
-  }
-
-  .contactPastorLink {
-    display: flex;
-    align-items: center;
-    align-content: center;
   }
 }

--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -1,7 +1,7 @@
 import React, { EventHandler, SyntheticEvent, CSSProperties } from 'react';
 import { Button } from 'reactstrap';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import AddToCalendar from '@esetnik/react-add-to-calendar';
+import AddToCalendar from '../AddToCalendar/AddToCalendar';
 import './HeroItem.scss';
 import Select from 'react-select';
 import DataLoader, { LocationData, LocationQuery } from './DataLoader';
@@ -52,11 +52,14 @@ class HeroItem extends React.Component<Props, State> {
     serviceHour = serviceHour.substr(0, serviceHour.indexOf(':'));
     nextSunday = nextSunday.hour(+serviceHour);
     const event = {
-      title: 'Church at The Meeting House',
+      summary: 'Church at The Meeting House',
       description: 'Join us at The Meeting House on Sunday!',
       location: locationItem.location.address,
-      startTime: nextSunday.format(),
-      endTime: moment(nextSunday).add(90, 'minutes').format(),
+      geo: `${locationItem.location.latitude};${locationItem.location.longitude}`,
+      rRule: 'WEEKLY',
+      start: nextSunday.format(),
+      end: moment(nextSunday).add(90, 'minutes').format(),
+      url: 'https://themeetinghouse.com/live',
     };
     return event;
   }
@@ -310,19 +313,12 @@ class HeroItem extends React.Component<Props, State> {
                 </Link>
               ) : this.state.content.addToCalendar ? (
                 this.state.locationData.length === 1 ? (
-                  <div className="HeroAddToCalendarButtonContainer">
-                    <img
-                      className="SundaMorningIcon"
-                      src="/static/svg/Calendar-white.svg"
-                      alt="Calendar Icon"
-                    />
-                    <AddToCalendar
-                      buttonLabel="Add to Calendar"
-                      event={this.getCalendarEventForLocation(
-                        this.state.locationData[0]
-                      )}
-                    ></AddToCalendar>
-                  </div>
+                  <AddToCalendar
+                    color="white"
+                    event={this.getCalendarEventForLocation(
+                      this.state.locationData[0]
+                    )}
+                  />
                 ) : null
               ) : null}
               {this.state.content.link1Text ? (

--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -314,27 +314,22 @@ class HeroItem extends React.Component<Props, State> {
               ) : this.state.content.addToCalendar ? (
                 this.state.locationData.length === 1 ? (
                   <AddToCalendar
+                    style={{ marginRight: 25 }}
+                    textDecoration="always"
                     color="white"
-                    event={this.getCalendarEventForLocation(
-                      this.state.locationData[0]
-                    )}
+                    event={{
+                      ...this.getCalendarEventForLocation(
+                        this.state.locationData[0]
+                      ),
+                      url: 'https://themeetinghouse.com/live',
+                    }}
                   />
                 ) : null
-              ) : null}
-              {this.state.content.link1Text ? (
-                <div className="heroAContainer">
-                  <Link
-                    className="heroBlackBoxA inverted"
-                    to={this.state.content.link1Action}
-                  >
-                    {this.state.content.link1Text}
-                  </Link>
-                </div>
               ) : null}
               {this.state.content.contactPastor ? (
                 this.state.locationData.length === 1 ? (
                   <a href={'mailto:' + this.state.locationData[0].pastorEmail}>
-                    <button className="calendarButton">
+                    <button className="calendarButton contactPastor">
                       <img
                         className="calendarImage"
                         src="/static/svg/Contact-white.svg"
@@ -346,6 +341,16 @@ class HeroItem extends React.Component<Props, State> {
                 ) : null
               ) : null}
             </div>
+            {this.state.content.link1Text ? (
+              <div className="heroAContainer">
+                <Link
+                  className="heroBlackBoxA inverted"
+                  to={this.state.content.link1Action}
+                >
+                  {this.state.content.link1Text}
+                </Link>
+              </div>
+            ) : null}
             <br />
           </div>
           {this.state.content.showCovid ? (

--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -1,7 +1,7 @@
 import React, { EventHandler, SyntheticEvent, CSSProperties } from 'react';
 import { Button } from 'reactstrap';
 import { withRouter, RouteComponentProps } from 'react-router-dom';
-import AddToCalendar from '../AddToCalendar/AddToCalendar';
+import AddToCalendar, { Event } from '../AddToCalendar/AddToCalendar';
 import './HeroItem.scss';
 import Select from 'react-select';
 import DataLoader, { LocationData, LocationQuery } from './DataLoader';
@@ -42,7 +42,7 @@ class HeroItem extends React.Component<Props, State> {
       locationData: this.state.locationData.concat(data),
     });
   }
-  getCalendarEventForLocation(locationItem: LocationData) {
+  getCalendarEventForLocation(locationItem: LocationData): Event {
     let nextSunday = (moment().day() === 0
       ? moment().add(1, 'week')
       : moment().day(0)
@@ -55,8 +55,6 @@ class HeroItem extends React.Component<Props, State> {
       summary: 'Church at The Meeting House',
       description: 'Join us at The Meeting House on Sunday!',
       location: locationItem.location.address,
-      geo: `${locationItem.location.latitude};${locationItem.location.longitude}`,
-      rRule: 'WEEKLY',
       start: nextSunday.format(),
       end: moment(nextSunday).add(90, 'minutes').format(),
       url: 'https://themeetinghouse.com/live',
@@ -317,12 +315,9 @@ class HeroItem extends React.Component<Props, State> {
                     style={{ marginRight: 25 }}
                     textDecoration="always"
                     color="white"
-                    event={{
-                      ...this.getCalendarEventForLocation(
-                        this.state.locationData[0]
-                      ),
-                      url: 'https://themeetinghouse.com/live',
-                    }}
+                    event={this.getCalendarEventForLocation(
+                      this.state.locationData[0]
+                    )}
                   />
                 ) : null
               ) : null}

--- a/src/components/RenderRouter/HomeChurchItem.scss
+++ b/src/components/RenderRouter/HomeChurchItem.scss
@@ -1,5 +1,18 @@
 @use '../../theme';
 
+.HomeChurchButtonContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+@media (max-width: 950px) {
+  .HomeChurchButtonContainer {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}
+
 .HomeChurchFormItemContainer {
   height: 149px;
   padding: 10px;
@@ -87,6 +100,9 @@
 }
 
 .ContactLeadersButton {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
   font-family: Graphik Web;
   color: theme.$onyxblacktext !important;
   background: #ffffff !important;
@@ -94,6 +110,7 @@
   border-radius: 0;
   font-size: 16px;
   text-decoration: none;
+  text-underline-offset: 0.25em;
   font-weight: normal;
   cursor: pointer;
   padding: 12px 0px;
@@ -109,86 +126,6 @@
   .ContactLeadersIcon {
     padding-right: 10px;
     height: 25px;
-  }
-}
-
-.AddToCalendarButtonContainer {
-  position: relative;
-  display: inline-block;
-  padding: 12px 30px 12px 0;
-
-  .AddToCalendarIcon {
-    position: absolute;
-    left: 0;
-    top: 0;
-    padding-right: 0;
-    padding-left: 0;
-    pointer-events: none;
-    top: 50%;
-    font-size: 12px;
-    transform: translateY(-50%);
-  }
-  .react-add-to-calendar__button {
-    font-family: Graphik Web;
-    color: theme.$onyxblacktext;
-    border-width: 0px;
-    border-radius: 0;
-    font-size: 16px;
-    font-weight: normal;
-    padding-left: 35px;
-    text-decoration: none !important;
-    cursor: pointer;
-    &:hover {
-      text-decoration: underline !important;
-    }
-  }
-  .react-add-to-calendar__dropdown {
-    position: absolute;
-    z-index: 100;
-    top: 48px;
-    background: white;
-    border: 1px solid theme.$onyxblacktext;
-    padding: 10px 20px 0 20px;
-    ul {
-      list-style-type: none;
-      padding: 0;
-      font-family: Graphik Web;
-      font-size: 14px;
-      a {
-        color: theme.$onyxblacktext !important;
-        vertical-align: middle;
-      }
-      li {
-        position: relative;
-        vertical-align: middle;
-      }
-      a::before {
-        width: 15px;
-        height: 15px;
-        vertical-align: middle;
-        background-size: contain;
-        background-position-y: center;
-        background-repeat: no-repeat;
-        display: inline-block;
-        content: '';
-        margin: 5px 5px 8px 0;
-      }
-      a.apple-link::before {
-        background-image: url('../../svg/Apple.svg');
-      }
-      a.outlook-link::before {
-        background-image: url('../../svg/Outlook.svg');
-      }
-      a.outlookcom-link::before {
-        background-image: url('../../svg/Outlook.svg');
-      }
-      a.yahoo-link::before {
-        background-image: url('../../svg/Yahoo.svg');
-      }
-      a.google-link::before {
-        background-image: url('../../svg/Google.svg');
-      }
-    }
   }
 }
 
@@ -445,15 +382,6 @@
     margin-bottom: 10px;
     color: theme.$onyxblacktext;
   }
-  .ContactLeadersButton {
-    font-size: 14px;
-  }
-
-  .AddToCalendarButtonContainer {
-    .react-add-to-calendar__button {
-      font-size: 14px;
-    }
-  }
 }
 
 @media (max-width: 767px) {
@@ -614,16 +542,6 @@
     margin-bottom: 3vh;
     padding-bottom: 3vh;
     border-bottom: 1px solid theme.$coolgray11;
-  }
-
-  .ContactLeadersButton {
-    font-size: 14px;
-  }
-
-  .AddToCalendarButtonContainer {
-    .react-add-to-calendar__button {
-      font-size: 14px;
-    }
   }
 
   .HomeChurchItemMapInfoWindowDiv1 {

--- a/src/components/RenderRouter/HomeChurchItem.tsx
+++ b/src/components/RenderRouter/HomeChurchItem.tsx
@@ -13,7 +13,7 @@ import {
 } from 'google-maps-react';
 import moment from 'moment';
 import React, { CSSProperties } from 'react';
-import AddToCalendar from '@esetnik/react-add-to-calendar';
+import AddToCalendar from '../AddToCalendar/AddToCalendar';
 import { isMobile } from 'react-device-detect';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Select, { Styles } from 'react-select';
@@ -362,7 +362,6 @@ export class ContentItem extends React.Component<Props, State> {
 
   private getCalendarEventForLocation(group: F1Group): any {
     let nextMeeting = moment();
-    //console.log('HomeChurchItem.getCalendarEventForLocation(): group = %o', group);
     for (const dayNum of [0, 1, 2, 3, 4, 5, 6]) {
       const recurrenceWeekly = group.schedule?.recurrences?.recurrence
         ?.recurrenceWeekly as Record<string, string> | undefined | null;
@@ -379,11 +378,11 @@ export class ContentItem extends React.Component<Props, State> {
       }
     }
     const event = {
-      title: group.name ?? undefined,
+      summary: group.name ?? undefined,
       description: 'Join us at home church!',
       location: this.formatGroupAddress(group).join(', '),
-      startTime: nextMeeting.format(),
-      endTime: moment(nextMeeting).add(2, 'hours').format(),
+      start: nextMeeting.format(),
+      end: moment(nextMeeting).add(2, 'hours').format(),
     };
     return event;
   }
@@ -788,17 +787,12 @@ export class ContentItem extends React.Component<Props, State> {
                       <div className="HomeChurchButtonContainer">
                         {item.schedule?.recurrences?.recurrence
                           ?.recurrenceWeekly ? (
-                          <div className="AddToCalendarButtonContainer">
-                            <img
-                              className="AddToCalendarIcon"
-                              src="/static/svg/Calendar, Add To.svg"
-                              alt="Calendar Icon"
-                            />
-                            <AddToCalendar
-                              buttonLabel="Add to Calendar"
-                              event={this.getCalendarEventForLocation(item)}
-                            ></AddToCalendar>
-                          </div>
+                          <AddToCalendar
+                            style={{ marginRight: 25 }}
+                            textDecoration="hover"
+                            color="black"
+                            event={this.getCalendarEventForLocation(item)}
+                          />
                         ) : null}
                         <button
                           className="ContactLeadersButton"

--- a/src/components/RenderRouter/HomeChurchItem.tsx
+++ b/src/components/RenderRouter/HomeChurchItem.tsx
@@ -13,7 +13,7 @@ import {
 } from 'google-maps-react';
 import moment from 'moment';
 import React, { CSSProperties } from 'react';
-import AddToCalendar from '../AddToCalendar/AddToCalendar';
+import AddToCalendar, { Event } from '../AddToCalendar/AddToCalendar';
 import { isMobile } from 'react-device-detect';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Select, { Styles } from 'react-select';
@@ -360,7 +360,7 @@ export class ContentItem extends React.Component<Props, State> {
     return address;
   }
 
-  private getCalendarEventForLocation(group: F1Group): any {
+  private getCalendarEventForLocation(group: F1Group): Event {
     let nextMeeting = moment();
     for (const dayNum of [0, 1, 2, 3, 4, 5, 6]) {
       const recurrenceWeekly = group.schedule?.recurrences?.recurrence
@@ -378,7 +378,7 @@ export class ContentItem extends React.Component<Props, State> {
       }
     }
     const event = {
-      summary: group.name ?? undefined,
+      summary: group.name ?? 'Home Church',
       description: 'Join us at home church!',
       location: this.formatGroupAddress(group).join(', '),
       start: nextMeeting.format(),

--- a/src/components/RenderRouter/SundayMorningItem.scss
+++ b/src/components/RenderRouter/SundayMorningItem.scss
@@ -1,5 +1,20 @@
 @use '../../theme';
 
+.SundayMorningButtonContainer {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  margin: 8px 0;
+}
+
+@media (max-width: 950px) {
+  .SundayMorningButtonContainer {
+    flex-direction: column;
+    align-items: flex-start;
+    margin: 10px 0 0;
+  }
+}
+
 .gm-style .gm-style-iw {
   background-color: #1a1a1a;
   color: white;
@@ -43,93 +58,14 @@
   }
 }
 
-.AddToCalendarButtonContainer {
-  position: relative;
-  display: inline-block;
-  padding: 12px 30px 12px 0;
-
-  .AddToCalendarIcon {
-    position: absolute;
-    left: 0;
-    top: 0;
-    padding-right: 0;
-    padding-left: 0;
-    pointer-events: none;
-    top: 50%;
-    font-size: 12px;
-    transform: translateY(-50%);
-  }
-  .react-add-to-calendar__button {
-    font-family: Graphik Web;
-    color: theme.$onyxblacktext;
-    border-width: 0px;
-    border-radius: 0;
-    font-size: 16px;
-    font-weight: normal;
-    padding-left: 35px;
-    text-decoration: none !important;
-    cursor: pointer;
-    &:hover {
-      text-decoration: underline !important;
-    }
-  }
-  .react-add-to-calendar__dropdown {
-    position: absolute;
-    z-index: 100;
-    top: 48px;
-    background: white;
-    border: 1px solid theme.$onyxblacktext;
-    padding: 10px 20px 0 20px;
-    ul {
-      list-style-type: none;
-      padding: 0;
-      font-family: Graphik Web;
-      font-size: 14px;
-      a {
-        color: theme.$onyxblacktext !important;
-        vertical-align: middle;
-      }
-      li {
-        position: relative;
-        vertical-align: middle;
-      }
-      a::before {
-        width: 15px;
-        height: 15px;
-        vertical-align: middle;
-        background-size: contain;
-        background-position-y: center;
-        background-repeat: no-repeat;
-        display: inline-block;
-        content: '';
-        margin: 5px 5px 8px 0;
-      }
-
-      a.apple-link::before {
-        background-image: url('../../svg/Apple.svg');
-      }
-      a.outlook-link::before {
-        background-image: url('../../svg/Outlook.svg');
-      }
-      a.outlookcom-link::before {
-        background-image: url('../../svg/Outlook.svg');
-      }
-      a.yahoo-link::before {
-        background-image: url('../../svg/Yahoo.svg');
-      }
-      a.google-link::before {
-        background-image: url('../../svg/Google.svg');
-      }
-    }
-  }
-}
-
 .ContactPastorIcon {
   padding-bottom: 2px;
 }
 
 .emailText {
   text-decoration: none;
+  color: theme.$onyxblacktext !important;
+  padding: 0;
 }
 
 @media (min-width: 768px) {
@@ -331,11 +267,6 @@
     margin-left: 1vw;
     padding: 0 10px 0 0;
   }
-
-  .emailText {
-    color: theme.$onyxblacktext !important;
-    padding: 0;
-  }
 }
 
 @media (min-width: 1025px) and (max-width: 1100px) {
@@ -345,10 +276,6 @@
 }
 
 @media (min-width: 768px) and (max-width: 1024px) and (orientation: portrait) {
-  .SundayMorningButtonContainer {
-    width: 190px;
-  }
-
   .emailButton {
     margin-left: 0 !important;
   }
@@ -490,12 +417,6 @@
     height: 25px;
   }
 
-  .AddToCalendarButtonContainer {
-    .react-add-to-calendar__button {
-      font-size: 14px;
-    }
-  }
-
   .emailButton {
     background-color: #ffffff00 !important;
     border: none !important;
@@ -505,12 +426,6 @@
     font-weight: normal;
     margin-left: 1vw;
     padding: 0 10px 0 0;
-  }
-
-  .emailText {
-    color: theme.$onyxblacktext !important;
-    font-size: 14px;
-    padding: 0;
   }
 }
 
@@ -695,13 +610,6 @@
     height: 25px;
   }
 
-  .AddToCalendarButtonContainer {
-    padding-right: 20px !important;
-    .react-add-to-calendar__button {
-      font-size: 14px;
-    }
-  }
-
   .emailButton {
     background-color: #ffffff00 !important;
     border: none !important;
@@ -711,11 +619,5 @@
     font-weight: normal;
     margin-left: 1vw;
     padding: 0 10px 0 0;
-  }
-
-  .emailText {
-    color: theme.$onyxblacktext !important;
-    font-size: 14px;
-    padding: 0;
   }
 }

--- a/src/components/RenderRouter/SundayMorningItem.tsx
+++ b/src/components/RenderRouter/SundayMorningItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'google-maps-react';
 import moment from 'moment';
 import React, { ChangeEvent } from 'react';
-import AddToCalendar from '@esetnik/react-add-to-calendar';
+import AddToCalendar from '../AddToCalendar/AddToCalendar';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Input } from 'reactstrap';
 import './SundayMorningItem.scss';
@@ -292,11 +292,11 @@ export class SundayMorningItem extends React.Component<Props, State> {
       const nextSunday = moment(locationItem.serviceTimes, 'MMMM D, h:mma');
       console.log(nextSunday);
       const event = {
-        title: 'Christmas at The Meeting House',
+        summary: 'Christmas at The Meeting House',
         description: 'Join us at The Meeting House for Christmas!',
         location: locationItem.location.address,
-        startTime: nextSunday.format(),
-        endTime: moment(nextSunday).add(90, 'minutes').format(),
+        start: nextSunday.format(),
+        end: moment(nextSunday).add(90, 'minutes').format(),
       };
       return event;
     } else {
@@ -309,11 +309,11 @@ export class SundayMorningItem extends React.Component<Props, State> {
       serviceHour = serviceHour.substr(0, serviceHour.indexOf(':'));
       nextSunday = nextSunday.hour(+serviceHour);
       const event = {
-        title: 'Church at The Meeting House',
+        summary: 'Church at The Meeting House',
         description: 'Join us at The Meeting House on Sunday!',
         location: locationItem.location.address,
-        startTime: nextSunday.format(),
-        endTime: moment(nextSunday).add(90, 'minutes').format(),
+        start: nextSunday.format(),
+        end: moment(nextSunday).add(90, 'minutes').format(),
       };
       return event;
     }
@@ -603,17 +603,12 @@ export class SundayMorningItem extends React.Component<Props, State> {
                           </div>
 
                           <div className="SundayMorningButtonContainer">
-                            <div className="AddToCalendarButtonContainer">
-                              <img
-                                className="AddToCalendarIcon"
-                                src="/static/svg/Calendar, Add To.svg"
-                                alt="Calendar Icon"
-                              />
-                              <AddToCalendar
-                                buttonLabel="Add to Calendar"
-                                event={this.getCalendarEventForLocation(item)}
-                              />
-                            </div>
+                            <AddToCalendar
+                              style={{ marginRight: 25 }}
+                              textDecoration="hover"
+                              color="black"
+                              event={this.getCalendarEventForLocation(item)}
+                            />
                             <a
                               className="emailText"
                               href={
@@ -622,13 +617,12 @@ export class SundayMorningItem extends React.Component<Props, State> {
                                   : 'mailto:' + item.pastorEmail
                               }
                             >
-                              <button className="emailButton">
-                                <img
-                                  className="ContactPastorIcon"
-                                  src="/static/svg/Contact.svg"
-                                  alt="Contact Icon"
-                                />
-                              </button>
+                              <img
+                                style={{ marginRight: 10 }}
+                                className="ContactPastorIcon"
+                                src="/static/svg/Contact.svg"
+                                alt="Contact Icon"
+                              />
                               {this.props.content.alternate === 'christmas'
                                 ? 'Connect'
                                 : 'Contact Pastor'}

--- a/src/components/RenderRouter/SundayMorningItem.tsx
+++ b/src/components/RenderRouter/SundayMorningItem.tsx
@@ -9,7 +9,7 @@ import {
 } from 'google-maps-react';
 import moment from 'moment';
 import React, { ChangeEvent } from 'react';
-import AddToCalendar from '../AddToCalendar/AddToCalendar';
+import AddToCalendar, { Event } from '../AddToCalendar/AddToCalendar';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Input } from 'reactstrap';
 import './SundayMorningItem.scss';
@@ -287,7 +287,7 @@ export class SundayMorningItem extends React.Component<Props, State> {
     this.setState({ selectedPlaceMarker: undefined, selectedPlace: item });
   };
 
-  getCalendarEventForLocation(locationItem: ListData) {
+  getCalendarEventForLocation(locationItem: ListData): Event {
     if (this.props.content.alternate === 'christmas') {
       const nextSunday = moment(locationItem.serviceTimes, 'MMMM D, h:mma');
       console.log(nextSunday);

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,1 +1,0 @@
-declare module '@esetnik/react-add-to-calendar';


### PR DESCRIPTION
3-for-1 special here.

- I created an `<AddToCalendar/>` component to replace `react-add-to-calendar`. Improves accessibility and removes a bunch of repeated CSS. Also, supports adding a URL to the calendar event. Closes #330.
- Add to calendar button on the Easter page. Closes #717.
- Fixes (recently introduced?) styling issues on the location pages. Closes #718.