### PR TITLE
Live events: allow overlapping custom events + dropdown UI

### DIFF
--- a/src/components/LiveEvents/Dropdown.scss
+++ b/src/components/LiveEvents/Dropdown.scss
@@ -113,7 +113,8 @@
   text-decoration: none;
   color: black;
 }
-.closeButton {
+.closeButton,
+.closeButtonContainer {
   display: none;
 }
 .FirstItemOffset {
@@ -123,7 +124,7 @@
 @media (max-width: 768px) {
   .DropdownMainContainer {
     position: fixed;
-    top: -35px;
+    top: 0;
     left: 0;
     min-width: 100%;
     z-index: 3000;
@@ -131,10 +132,12 @@
   }
   .DropdownFill {
     position: fixed;
+    margin-top: 0;
     min-width: 100%;
-    min-height: calc(100% + 35px);
+    min-height: 100%;
     animation: slideInMobile;
     animation-duration: 0.2s;
+    overscroll-behavior: contain;
   }
   .triangle {
     display: none;
@@ -177,13 +180,19 @@
     font-family: Graphik Web;
     font-size: 0.8rem;
   }
-  .closeButton {
-    left: calc(85% - 16px);
-    position: relative;
-    margin-top: 24px;
-    display: unset;
-    z-index: 200;
+
+  .closeButtonContainer {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    .closeButton {
+      margin-top: 24px;
+      margin-right: 24px;
+      display: unset;
+      z-index: 200;
+    }
   }
+
   .EventFooter {
     margin-top: 24px;
     font-size: calc(12px + 0.3vw);

--- a/src/components/LiveEvents/Dropdown.tsx
+++ b/src/components/LiveEvents/Dropdown.tsx
@@ -82,13 +82,15 @@ const Dropdown = ({ end, close, liveevents }: Props) => {
     <div ref={ref} className="DropdownMainContainer">
       <div className="triangle"></div>
       <div className="DropdownFill">
-        <img
-          onClick={close}
-          className="closeButton"
-          style={{}}
-          alt="Close Icon"
-          src="/static/svg/Close-Cancel-White.svg"
-        ></img>
+        <div className="closeButtonContainer">
+          <img
+            onClick={close}
+            className="closeButton"
+            style={{}}
+            alt="Close Icon"
+            src="/static/svg/Close-Cancel-White.svg"
+          />
+        </div>
         {!isLoading ? (
           <>
             {events.map((event: any, ind: any) => {

--- a/src/pages/admin/livestream.tsx
+++ b/src/pages/admin/livestream.tsx
@@ -340,29 +340,34 @@ class Index extends React.Component<EmptyProps, State> {
         test = false;
       }
 
-      livestreamList?.forEach((item) => {
-        if (
-          item?.date === date &&
-          item?.id !== id &&
-          startTime &&
-          endTime &&
-          item?.startTime &&
-          item?.endTime
-        ) {
-          if (item.startTime <= startTime && item.endTime >= startTime) {
-            this.setState({
-              alert: `error: live event overlaps with ${item?.id}`,
-            });
-            test = false;
+      if (!this.state.customEvent) {
+        // custom live events may overlap
+
+        livestreamList?.forEach((item) => {
+          if (
+            !item?.externalEventUrl && // skip custom live events
+            item?.date === date &&
+            item?.id !== id &&
+            startTime &&
+            endTime &&
+            item?.startTime &&
+            item?.endTime
+          ) {
+            if (item.startTime <= startTime && item.endTime >= startTime) {
+              this.setState({
+                alert: `error: live event overlaps with ${item?.id}`,
+              });
+              test = false;
+            }
+            if (item.startTime <= endTime && item.endTime >= endTime) {
+              this.setState({
+                alert: `error: live event overlaps with ${item?.id}`,
+              });
+              test = false;
+            }
           }
-          if (item.startTime <= endTime && item.endTime >= endTime) {
-            this.setState({
-              alert: `error: live event overlaps with ${item?.id}`,
-            });
-            test = false;
-          }
-        }
-      });
+        });
+      }
 
       if (prerollYoutubeId === '' && startTime !== videoStartTime) {
         this.setState({


### PR DESCRIPTION
@lucastbelem we're good to go - I got to this a bit early 🎉

- Custom live events may now overlap with any other live events.
- Livestreams (the ones that show up on https://themeetinghouse.com/live) still cannot overlap with each other (status quo here).

I did a test with 20 events to make sure everything works. During my testing I noticed (and fixed) some issues with the dropdown UI  on mobile/tablet:
- I added `overscroll-behavior: contain` to prevent the document underneath the dropdown from scrolling.
- On tablet, the close button is too far from the right edge, so re-implemented with flexbox:

| Before    | After   |
| --- | --- |
| <img src=https://user-images.githubusercontent.com/48423418/112934624-2e673a80-90f0-11eb-88cf-c3ef8aee31c2.png width=350> | <img src=https://user-images.githubusercontent.com/48423418/112934625-2effd100-90f0-11eb-9ee3-17179b798911.png width=350>|

- On mobile, the "All times displayed in {timezone}" text was getting cut off:

| Before   | After   |
| --- | --- |
|<img src=https://user-images.githubusercontent.com/48423418/112934626-2effd100-90f0-11eb-8a61-bfbbfe987d6e.png width=300> | <img src=https://user-images.githubusercontent.com/48423418/112934627-2effd100-90f0-11eb-8de3-d3f9550e0cf4.png width=300> |

Resolves #721.