### PR TITLE
Force [skip-cd] to new line

### DIFF
--- a/scripts/commit-msg.sh
+++ b/scripts/commit-msg.sh
@@ -4,8 +4,10 @@ PUBLIC_STATIC=$(git diff --name-only --cached -- public/static)
 REPO=$(git diff --name-only --cached)
 COMMIT_MSG=$(cat $HUSKY_GIT_PARAMS)
 
+SKIP_CD=$'\n[skip-cd]'
+
 if [[ $COMMIT_MSG == "Merge branch 'master' of"* ]]; then
-  echo "[skip-cd]" >> $HUSKY_GIT_PARAMS
+  echo "$SKIP_CD" >> $HUSKY_GIT_PARAMS
 elif [ "$PUBLIC_STATIC" == "$REPO" ] && [ -n "$PUBLIC_STATIC" ]; then
-  echo "[skip-cd]" >> $HUSKY_GIT_PARAMS
+  echo "$SKIP_CD" >> $HUSKY_GIT_PARAMS
 fi


### PR DESCRIPTION
On merge commits, [skip-cd] sometimes gets appended to the repo URL.

Example (https://github.com/themeetinghouse/web/commit/4b84796635e9e1e23c0bdeccddfe0b9d728d9172): Merge branch 'master' of https://github.com/themeetinghouse/web[skip-cd]

Added `\n` to ensure that [skip-cd] starts on a new line.