### PR TITLE
Added secondary CTA for hero style full

### DIFF
--- a/public/static/svg/Register-white.svg
+++ b/public/static/svg/Register-white.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.712 16.386L9 16.916L9.53 13.2L19.076 3.65399C19.956 2.77499 21.381 2.77599 22.26 3.65599C23.139 4.53599 23.138 5.96099 22.258 6.83999L12.712 16.386Z" stroke="#FFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M5.25 15H2.25C1.422 15 0.75 15.672 0.75 16.5V19.5C0.75 20.328 1.422 21 2.25 21H21.75C22.578 21 23.25 20.328 23.25 19.5V16.5C23.25 15.672 22.578 15 21.75 15H18.75" stroke="#FFF" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/RenderRouter/HeroItem.scss
+++ b/src/components/RenderRouter/HeroItem.scss
@@ -11,7 +11,20 @@
 .heroAContainer {
   margin-top: 1vw;
 }
-
+.secondaryCTA {
+  font-size: 1.2vw;
+  font-family: Graphik Web !important;
+  color: #ffffff;
+  font-weight: normal;
+  background-color: theme.$onyxblacktext !important;
+  border-width: 0 !important;
+  border-radius: 0;
+  text-decoration: underline !important;
+  margin-left: 30px;
+}
+.secondaryCTA:hover {
+  color: white;
+}
 .contactPastorLink {
   margin-top: 16px;
   display: flex;
@@ -767,6 +780,9 @@ $no-footer-height: 38vw;
 }
 
 @media (max-width: 1050px) {
+  .secondaryCTA {
+    margin-left: 0px;
+  }
   .contactPastorLink {
     margin-top: 16px;
     display: flex;
@@ -780,6 +796,9 @@ $no-footer-height: 38vw;
 }
 
 @media (max-width: 767px) {
+  .secondaryCTA {
+    font-size: 14px;
+  }
   .covidButtonDetail {
     background-color: #ffc60b !important;
 

--- a/src/components/RenderRouter/HeroItem.tsx
+++ b/src/components/RenderRouter/HeroItem.tsx
@@ -232,6 +232,30 @@ class HeroItem extends React.Component<Props, State> {
       </Button>
     ) : null;
   }
+
+  renderSecondaryCTA(buttonInfo: any) {
+    if (!buttonInfo) return null;
+    return (
+      <Link
+        to={buttonInfo.action}
+        className="secondaryCTA"
+        style={{
+          marginTop: 20,
+        }}
+        aria-label={buttonInfo.description}
+      >
+        {buttonInfo.icon ? (
+          <img
+            className="calendarImage"
+            src={buttonInfo.icon}
+            alt={`${buttonInfo.text} Icon`}
+          />
+        ) : null}
+        {buttonInfo.text}
+      </Link>
+    );
+  }
+
   render() {
     window.onscroll = () => {
       this.downArrowScroll();
@@ -279,7 +303,7 @@ class HeroItem extends React.Component<Props, State> {
                     height={25}
                     className="calendarImage"
                     src="/static/svg/Play.svg"
-                    alt="Contact Icon"
+                    alt="Play Icon"
                   />
                   Watch Live
                 </Link>
@@ -295,7 +319,7 @@ class HeroItem extends React.Component<Props, State> {
                     height={25}
                     className="calendarImage"
                     src="/static/svg/Play.svg"
-                    alt="Contact Icon"
+                    alt="Play Icon"
                   />
                   Watch Live
                 </Link>
@@ -344,6 +368,8 @@ class HeroItem extends React.Component<Props, State> {
                     />
                   )
                 ) : null
+              ) : this.state.content.secondaryCTA ? (
+                this.renderSecondaryCTA(this.state.content.secondaryCTA)
               ) : null}
               {this.state.content.contactPastor ? (
                 this.state.locationData.length === 1 ? (


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42515854/129507801-81deaf08-b995-4cfe-914a-a587005c08b5.png)
Add the highlighted code to add a secondary button to hero. Must be style = 'full'
"secondaryCTA": {
 "text": "Registration",
 "action": "/registration",
 "description": "Navigate to registration page",
 "icon": "/static/svg/Register-white.svg"
}

closes #815

