### PR TITLE
Fixed announcement image url

### DIFF
--- a/src/pages/admin/Announcements.tsx
+++ b/src/pages/admin/Announcements.tsx
@@ -360,7 +360,7 @@ export default function Announcements(): JSX.Element {
   ) => {
     switch (conditional) {
       case true:
-        return `https://themeetinghouse.com/cached/640/static/photos/announcements/${
+        return `https://themeetinghouse.com/static/photos/announcements/${
           announcement?.publishedDate
         }_${announcement?.title.replaceAll(' ', '_')}.jpg`;
       default:


### PR DESCRIPTION
Announcements created should now use the correct urls for images. ( will only apply to new announcements as of when this gets merged..)