### PR TITLE
Added custom yellow announcement bar

### DIFF
--- a/src/components/AnnouncementBar/AnnouncementBar.tsx
+++ b/src/components/AnnouncementBar/AnnouncementBar.tsx
@@ -6,7 +6,8 @@ import { ListLivestreamsQuery } from '../../API';
 import { API } from 'aws-amplify';
 import { GraphQLResult, GRAPHQL_AUTH_MODE } from '@aws-amplify/api';
 import moment from 'moment-timezone';
-import './AnnouncementBar.scss';
+import YellowAnnouncement from './YellowAnnouncement';
+
 type Props = {
   showLive: boolean;
   setShowBar: (val: boolean) => void;
@@ -80,26 +81,10 @@ const AnnouncementBar = ({ showLive, setShowBar }: Props) => {
   return (
     <>
       {showLiveBanner ? (
-        <button
-          aria-label="Events List"
-          style={{
-            position: 'fixed',
-            zIndex: 10000,
-            top: 0,
-            left: 0,
-            padding: 0,
-            margin: 0,
-            border: 'none',
-            outline: 'none !important',
-            outlineOffset: 'none !important',
-          }}
-          className="ignore-onClickOutside"
+        <YellowAnnouncement
+          title={liveTitle}
           onClick={() => setShowDropdown((prev) => !prev)}
-        >
-          <div className="AnnouncementBarContainer">
-            <p className="bannerMessage">{liveTitle}</p>
-          </div>
-        </button>
+        />
       ) : null}
       {showDropdown ? (
         <Dropdown

--- a/src/components/AnnouncementBar/YellowAnnouncement.scss
+++ b/src/components/AnnouncementBar/YellowAnnouncement.scss
@@ -1,6 +1,6 @@
 @use '../../theme';
 
-.AnnouncementBarContainer {
+.AnnouncementContainer {
   display: flex;
   justify-content: center;
   align-content: center;
@@ -13,7 +13,7 @@
   margin: auto;
   cursor: pointer;
 }
-.bannerMessage {
+.AnnouncementMessage {
   text-align: center;
   margin-top: auto;
   margin-bottom: auto;
@@ -24,12 +24,12 @@
 }
 
 @media (max-width: 767px) {
-  .AnnouncementBarContainer {
+  .AnnouncementContainer {
     top: 19.2vw;
     height: calc(52px + 1vh);
     position: absolute;
   }
-  .bannerMessage {
+  .AnnouncementMessage {
     padding-right: 4px;
     padding-left: 4px;
     font-size: 0.9em;

--- a/src/components/AnnouncementBar/YellowAnnouncement.tsx
+++ b/src/components/AnnouncementBar/YellowAnnouncement.tsx
@@ -1,0 +1,31 @@
+import './YellowAnnouncement.scss';
+
+type YellowAnnouncementProps = {
+  title: string;
+  onClick: () => void;
+};
+export default function YellowAnnouncement(props: YellowAnnouncementProps) {
+  const { title, onClick } = props;
+  return (
+    <button
+      aria-label={title}
+      style={{
+        position: 'fixed',
+        zIndex: 10000,
+        top: 0,
+        left: 0,
+        padding: 0,
+        margin: 0,
+        border: 'none',
+        outline: 'none !important',
+        outlineOffset: 'none !important',
+      }}
+      className="ignore-onClickOutside"
+      onClick={onClick}
+    >
+      <div className="AnnouncementContainer">
+        <p className="AnnouncementMessage">{title}</p>
+      </div>
+    </button>
+  );
+}

--- a/src/components/Menu/HomeMenu.tsx
+++ b/src/components/Menu/HomeMenu.tsx
@@ -20,6 +20,7 @@ import { EditorContext } from '../../pages/admin/Editor/EditorContext';
 import RSNavLinkWrapper from './RSNavLinkWrapper';
 import TMHLogo from './TMHLogo';
 import ExpandButton from './ExpandButton';
+import YellowAnnouncement from 'components/AnnouncementBar/YellowAnnouncement';
 const VideoOverlay = React.lazy(() => import('../VideoOverlay/VideoOverlay'));
 const AnnouncementBar = React.lazy(
   () => import('../../components/AnnouncementBar/AnnouncementBar')
@@ -170,6 +171,24 @@ class HomeMenu extends React.Component<Props, State> {
           setShowBar={(val) => this.setState({ logoOffset: val })}
           showLive={this.state.showLive}
         />
+        {this.props.pageConfig.showYellowBar && !this.state.logoOffset ? (
+          <YellowAnnouncement
+            title={this.props.pageConfig.showYellowBar.text}
+            onClick={() => {
+              if (this.props.pageConfig.showYellowBar.action.includes('http')) {
+                window.open(
+                  this.props.pageConfig.showYellowBar.action,
+                  '_blank'
+                );
+                return;
+              } else
+                this.props.history.push(
+                  this.props.pageConfig.showYellowBar.action
+                );
+            }}
+          />
+        ) : null}
+
         <div>
           <div
             className={
@@ -182,7 +201,9 @@ class HomeMenu extends React.Component<Props, State> {
           >
             <NavbarBrand tag={Link} className="brand" to="/">
               <TMHLogo
-                offset={this.state.logoOffset}
+                offset={
+                  this.state.logoOffset || this.props.pageConfig.showYellowBar
+                }
                 logoColor={this.state.logoColor}
                 showLogoText={this.state.showLogoText}
               />
@@ -192,7 +213,11 @@ class HomeMenu extends React.Component<Props, State> {
               <div>
                 <Button
                   aria-label="Search the meeting house website"
-                  className="search"
+                  className={`search ${
+                    this.props.pageConfig.showYellowBar || this.state.logoOffset
+                      ? 'offset'
+                      : ''
+                  }`}
                   onClick={() => this.setState({ overlayType: 'search' })}
                 >
                   <img src="/static/svg/Search.svg" alt="Search" />

--- a/src/components/Menu/menu.scss
+++ b/src/components/Menu/menu.scss
@@ -81,6 +81,9 @@
     &:focus {
       background-color: #efeff0;
     }
+    &.offset {
+      top: 56px;
+    }
   }
 
   .navbar-toggler {
@@ -280,6 +283,9 @@
     }
     &:focus {
       background-color: #efeff0;
+    }
+    &.offset {
+      top: 56px;
     }
   }
   .liveEvent {


### PR DESCRIPTION
Add the following to pageConfig in pages to show the yellow bar. The live events bar will override this if there are active events.

       "showYellowBar": {
        "text": "Give Today",
        "action": "/give"
      },

<img width="330" alt="Screenshot 2022-12-18 at 10 57 19 PM" src="https://user-images.githubusercontent.com/42515854/207716309-8e5b54ef-1d7d-4982-91ca-4d6159ab88a0.png">

closes #1097 
